### PR TITLE
Mac 以外でビルドが通らない

### DIFF
--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -1,6 +1,6 @@
 
 var L = require('leaflet');
-var $ = require('jQuery');
+var $ = require('jquery');
 var numberIcon = require('./leaflet_awesome_number_markers');
 
 $(function(){


### PR DESCRIPTION
`var $ = require('jQuery');`
本来はライブラリ名はjqueryが正しいのですが，Macでは大文字と小文字を区別しないので，ビルドできてしまいます。Windowsなどでビルドできません。