### PR TITLE
trの途中で改ページされてしまうのを修正

### DIFF
--- a/source/stylesheets/site.scss
+++ b/source/stylesheets/site.scss
@@ -87,6 +87,9 @@ body {
           vertical-align: bottom;
           padding-left: 32px;
         }
+        tr {
+          page-break-inside: avoid;
+        }
         td {
           border-collapse: collapse;
           border-spacing: 0;
@@ -119,4 +122,9 @@ body {
       display: none;
     }
   }
+}
+
+
+@page {
+  size: A4;
 }


### PR DESCRIPTION
trの途中で改ページがおきてしまって、見栄えば悪かったので修正しました。
読むのに困らなかったとは思いますが、念のため。

* 修正前

<img width="1239" alt="2018-07-13 15 42 33" src="https://user-images.githubusercontent.com/459739/42676810-7a633c48-86b4-11e8-89a6-d448efe476c1.png">

* 修正後

<img width="1248" alt="2018-07-13 15 42 49" src="https://user-images.githubusercontent.com/459739/42676818-87bf4c38-86b4-11e8-98ab-689c90bb2565.png">
