### PR TITLE
Fixed #33 circleciの設定を追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2 # use CircleCI 2.0
+jobs: # a collection of steps
+  build: # runs not using Workflows must have a `build` job as entry point
+    working_directory: ~/ssr # directory where steps will run
+    docker: # run the steps with Docker
+      - image: circleci/ruby:2.4-node # ...with this image as the primary container; this is where all `steps` will run
+        environment: # environment variables for primary container
+          BUNDLE_JOBS: 3
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+    steps: # a collection of executable commands
+      - checkout # special step to check out source code to working directory
+
+      # Which version of bundler?
+      - run:
+          name: Which bundler?
+          command: bundle -v
+
+      # Restore bundle cache
+      - restore_cache:
+          keys:
+            - bundle-v2-{{ checksum "Gemfile.lock" }}
+            - bundle-v2-
+
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+
+      # Store bundle cache
+      - save_cache:
+          key: bundle-v2-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+
+      # Only necessary if app uses webpacker or yarn in some other way
+      - restore_cache:
+          keys:
+            - npm-{{ checksum "package.json" }}
+            - npm-
+
+      - run:
+          name: npm Install
+          command: npm install
+
+      - run:
+          name: build middleman
+          command: |
+            bundle exec middleman build
+
+      - run:
+          name: run test
+          command: |
+            npm test
+
+      - add_ssh_keys
+      - deploy:
+          name: start master deploy
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                bundle exec middleman deploy
+            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,10 @@
 version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
-    working_directory: ~/ssr # directory where steps will run
+    branches:
+      ignore:
+        - gh-pages
+    working_directory: ~/mapprint # directory where steps will run
     docker: # run the steps with Docker
       - image: circleci/ruby:2.4-node # ...with this image as the primary container; this is where all `steps` will run
         environment: # environment variables for primary container
@@ -41,6 +44,13 @@ jobs: # a collection of steps
       - run:
           name: npm Install
           command: npm install
+          
+      # Store npm cache
+      - save_cache:
+          key: npm-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+          
 
       - run:
           name: build middleman
@@ -57,5 +67,8 @@ jobs: # a collection of steps
           name: start master deploy
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                git config --global user.email info@code4japan.org
+                git config --global user.name circleci
+                git fetch origin gh-pages
                 bundle exec middleman deploy
             fi

--- a/config.rb
+++ b/config.rb
@@ -68,7 +68,7 @@ end
 activate :deploy do |deploy|
   deploy.build_before = true
   deploy.deploy_method = :git
-  deploy.remote = 'git@github.com:kkanazaw/mapprint.git'
+  deploy.remote = 'git@github.com:codeforjapan/mapprint.git'
   deploy.branch = 'gh-pages'
   deploy.commit_message = "[ci skip] Automated commit at #{Time.now.utc} by middleman-deploy #{Middleman::Deploy::PACKAGE} #{Middleman::Deploy::VERSION}"
 end

--- a/config.rb
+++ b/config.rb
@@ -68,6 +68,7 @@ end
 activate :deploy do |deploy|
   deploy.build_before = true
   deploy.deploy_method = :git
-  deploy.remote = 'git@github.com:codeforjapan/mapprint.git'
+  deploy.remote = 'git@github.com:kkanazaw/mapprint.git'
   deploy.branch = 'gh-pages'
+  deploy.commit_message = "[ci skip] Automated commit at #{Time.now.utc} by middleman-deploy #{Middleman::Deploy::PACKAGE} #{Middleman::Deploy::VERSION}"
 end


### PR DESCRIPTION
# 概要
fixed #33 
circleciをつかってgh-pagesブランチに自動デプロイする設定を作成いたしました。

# デプロイの流れ
- トピックブランチにpushされたら、circleciが起動して
   -  bundle exec middleman buildとnpm testを実行
- masterブランチにpushされたら circleciが起動
    - bundle exec middleman deployを実行
    - gh-pagesブランチに force pushされます(後述の問題がのこっています)

# 設定のに必要なもの
- circleciのアカウントcodeforjapan/mapprintをbuild
- github organizationのowner権限
- gitにpushするための公開鍵/秘密鍵 
- (slackに通知したい場合は)、slackのcircleci app導入

# 設定方法

## circleciへの登録
circleciにログインして、このリポジトリをbuild対象に登録します。
https://circleci.com/docs/2.0/#setting-up-your-build-on-circleci

## 鍵の登録方法
- 公開鍵をgithubのdeploy keyにwrite権限ありで登録
- 秘密鍵をcircleciのSSH Permissionsに登録

登録方法は下記のサイトがキャプチャ入りでわかりやすいです。
https://blog.yuyat.jp/post/auto-deploy-hugo-to-github-pages-with-circleci/

## ブランチのマージ
このブランチをmasterにマージすると、ビルドがスタートします。

# 問題点
一点問題があって、middlemanのコマンドがpush -fのときに gh-pagesのコミット履歴が消えてしまいます。
circleci内でgit cloneを工夫すればできそうなのですが、解決できていません。
もし解決方法ご存知の方いらっしゃいましたら、コメントお願いいたします。

[![Image from Gyazo](https://i.gyazo.com/a2babed4bd658a98df5f59f33b5df268.png)](https://gyazo.com/a2babed4bd658a98df5f59f33b5df268)

