### PR TITLE
使われていない変数`index`を削除

### DIFF
--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -137,7 +137,6 @@ $(function(){
         window.history.pushState('', '', path + '#' + s);
         renewQRCode();
         $('#list').html('<table>');
-        var index = 0;
         var targets = [];
         this.eachLayer(function(layer) {
             if(layer instanceof L.Marker)


### PR DESCRIPTION
[下の方](https://github.com/codeforjapan/mapprint/blob/dd8cddfba54bd3ae63c4b44a9d3f49cf79facbd5/source/javascripts/all.js#L174-L204)で使われている`index`は`forEach`のfunctionの引数として導入されているものなので、
こちらは不要なはずです。