### PR TITLE
タスクの改善 #109

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ git clone git@github.com:codeforjapan/mapprint.git
 cd mapprint
 npm install
 bundle install --path=vendor/bundle
+npm run lint
+npm test
 bundle exec middleman build
 ```
 

--- a/config.rb
+++ b/config.rb
@@ -68,7 +68,7 @@ end
 activate :deploy do |deploy|
   deploy.build_before = true
   deploy.deploy_method = :git
-  deploy.remote = 'git@github.com:codeforjapan/mapprint.git'
+  deploy.remote = 'origin'
   deploy.branch = 'gh-pages'
   deploy.commit_message = "[ci skip] Automated commit at #{Time.now.utc} by middleman-deploy #{Middleman::Deploy::PACKAGE} #{Middleman::Deploy::VERSION}"
 end


### PR DESCRIPTION
- middleman deploy 時の deploy.remote を 'origin' に変更
- READMEにテスト用コマンド追記