### PR TITLE
説明文が印刷分と重なる問題を修正

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -1,18 +1,6 @@
 ---
 title: 給水所/お風呂/洗濯（ランドリー）マップ
 ---
-%section.sheet
-    #header
-        #qrcodecontainer
-        データ最終更新日：
-        %span#datetime
-    #content
-        #page
-            %h1 給水所/お風呂/洗濯（ランドリー）マップ
-            #date.print_area
-            #map
-            #list
-    #footer.print_area
 #explain.not_print_area
     %button#print 印刷する（A4タテ）
     %br
@@ -41,3 +29,15 @@ title: 給水所/お風呂/洗濯（ランドリー）マップ
             このサイトのソースコードはオープンに公開しております。開発にご協力いただける方は、
             %a{:href=>"https://github.com/codeforjapan/mapprint"} Code for Japan の Github リポジトリ
             から、開発にご参加ください。JavaScript や Leaflet などの経験がある方、大歓迎です。
+%section.sheet
+    #header
+        #qrcodecontainer
+        データ最終更新日：
+        %span#datetime
+    #content
+        #page
+            %h1 給水所/お風呂/洗濯（ランドリー）マップ
+            #date.print_area
+            #map
+            #list
+    #footer.print_area

--- a/source/stylesheets/site.scss
+++ b/source/stylesheets/site.scss
@@ -188,6 +188,13 @@ body {
   }
 }
 
+@media (max-width: 1248px) {
+  #explain {
+    width:210mm;
+    position: static;
+  }
+}
+
 @page {
   size: A4;
   margin: 10mm;


### PR DESCRIPTION
<img width="1313" alt="2018-07-19 0 45 43" src="https://user-images.githubusercontent.com/459739/42893340-0a64ca80-8aef-11e8-918b-b31ae7598a44.png">

Windowの幅や解像度によって地図と説明文が重なってしまうことがあったので、
幅が狭いときは地図の上に説明文を表示するようにした。

幅が広い時
<img width="1389" alt="2018-07-19 0 57 18" src="https://user-images.githubusercontent.com/459739/42893392-29b18054-8aef-11e8-87e2-fde0125ae2ee.png">

幅が狭い時
<img width="1306" alt="2018-07-19 0 57 23" src="https://user-images.githubusercontent.com/459739/42893408-31c8f5b0-8aef-11e8-99fd-4d6f99e856b4.png">
