### PR TITLE
Mac Safari で印刷時にマップが表示されない不具合を修正

### DIFF
--- a/source/javascripts/mapHelper.ts
+++ b/source/javascripts/mapHelper.ts
@@ -61,6 +61,7 @@ export default class PrintableMap implements IPrintableMap{
       center: [127.88768305343456,26.710444962177604],
       zoom: 13,
       bounds: this.defbounds,
+      preserveDrawingBuffer: true,
       style: {
         "version": 8,
         "sources": {


### PR DESCRIPTION
#151 を修正しました。

こちらを参考にしました。
https://github.com/mapbox/mapbox-gl-js/issues/4505

OSXで検証しています。
chromeについては、ページ内の「印刷する」ボタンを押さないと印刷できないのは仕様ですか？（ブラウザのメニューからは印刷できませんでした）
それと、Windowsでの検証が必要かもしれません。