### PR TITLE
#167 MIERUNE地図対応

### DIFF
--- a/source/javascripts/mapHelper.ts
+++ b/source/javascripts/mapHelper.ts
@@ -67,7 +67,7 @@ export default class PrintableMap implements IPrintableMap{
         "sources": {
           "OSM": {
             "type": "raster",
-            "tiles": [ tileServerUrl('moXno', host )],
+            "tiles": tileServerUrl('moXno', host ),
             "tileSize": 256
           }
         },
@@ -284,7 +284,7 @@ export function tileServerAttribution(host:string):string{
   'Map data © <a href="http://openstreetmap.org/">OpenStreetMap</a>';
 }
 
-export function tileServerUrl(mapStyle:string, host:string):string{
+export function tileServerUrl(mapStyle:string, host:string):Array<string>{
   // 地図の色はnormal,grey, mono, bright, blueが選択できる。
   // 印刷時の視認性の高さからカラーはbright、白黒にはgrayを使用する。
   var styleCode;
@@ -298,8 +298,8 @@ export function tileServerUrl(mapStyle:string, host:string):string{
   // MIERUNEMAPのAPIキーはローカル環境では表示されないのでご注意(https://codeforjapan.github.io/以下でのみ表示される）
   // サーバ上の場合のみMIERUNE地図を使う
   return ( host === 'codeforjapan.github.io' ) ?
-  'https://tile.cdn.mierune.co.jp/styles/' + styleCode + '/{z}/{x}/{y}.png?key=KNmswjVYR187ACBqbsZc5fEIBM_DC2TXwMST0tVMe4AiYCt274X0VqAy5pf-ebvl8CtjAtBx15r1YyAiXURC' :
-  'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png';
+  ['https://tile.cdn.mierune.co.jp/styles/' + styleCode + '/{z}/{x}/{y}.png?key=KNmswjVYR187ACBqbsZc5fEIBM_DC2TXwMST0tVMe4AiYCt274X0VqAy5pf-ebvl8CtjAtBx15r1YyAiXURC'] :
+  ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png', 'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png', 'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png'];
 }
 function serializeLatLng(latLng) {
   return '' + latLng.lat + ',' + latLng.lng;

--- a/source/javascripts/site.ts
+++ b/source/javascripts/site.ts
@@ -3,7 +3,7 @@ import PrintableMap from './mapHelper';
 
 $(function(){
   if ($('#map')){
-    let map = new PrintableMap("localhost:4567", "map");
+    let map = new PrintableMap(window.location.hostname, "map");
     map.loadFile('./images/chiba.kml');
   }
   $('#print').on('click', () => {

--- a/source/stylesheets/map.scss
+++ b/source/stylesheets/map.scss
@@ -43,18 +43,23 @@ body {
   font-size: 3.5mm;
   text-align: right;
   width: 100% !important;
-  height: 24px;
+  @media screen {
+    height: 24px;
+  }
+  @media print {
+    max-height: 24px;
+  }
   #logo {
-    float:left;
-    width:200px;
+    @media print {
+      display: none;
+    }
+    @media screen {
+      float:left;
+      width:200px;
+    }
   }
   #datetime_block {
-    @media screen and (min-width:0px) {
-      float:right;
-    }
-    @media screen and (min-width:450px) {
-      float:right;
-    }
+    float:right;
   }
   #qrcodecontainer {
     float: left;


### PR DESCRIPTION
https://github.com/codeforjapan/mapprint/pull/176 を含んでいるので注意してください。

1. host名がlocalhostに決め打ちになっていたので、 MIERUNE地図に対応するようwindow.location.hostname を利用するようにした
2. せっかくなのでosm.org のタイルサーバを見る場合は a だけでなく a,b,c のサーバを参照するようにした