### PR TITLE
fixes: #171 replace site title

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -1,5 +1,5 @@
 ---
-title: 千葉県サポート情報
+title: 印刷できる台風災害支援情報マップ（千葉県）
 ---
 - content_for(:header) do
   = stylesheet_link_tag "index"

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -4,12 +4,12 @@
     %meta{:charset=>"utf-8"}
     %meta{"http-equiv"=>"x-ua-compatible", :content=>"ie=edge"}
     %meta{:name=>"viewport", :content=>"width=device-width, initial-scale=1, shrink-to-fit=no"}
-    %title 千葉県サポート情報
-    %meta{:property=>"og:title", :content=>"千葉県サポート情報"}
+    %title 印刷できる台風災害支援情報マップ（千葉県）
+    %meta{:property=>"og:title", :content=>"印刷できる台風災害支援情報マップ（千葉県）"}
     %meta{:property=>"og:type", :content=>"website"}
     %meta{:property=>"og:url", :content=>"https://codeforjapan.github.io/mapprint/"}
     %meta{:property=>"og:image", :content=>"https://codeforjapan.github.io/mapprint/images/thumbnail.png"}
-    %meta{:property=>"og:site_name", :content=>"千葉県サポート情報"}
+    %meta{:property=>"og:site_name", :content=>"印刷できる台風災害支援情報マップ（千葉県）"}
     %meta{:property=>"og:description", :content=>"千葉県の災害に対して、SNSで流れる給水所などの情報や、行政発信の情報を見れていない地域の人たちにも伝えるために、情報をA4にまとめて印刷してくばれるように情報を最適化しています。"}
     %meta{:property=>"fb:app_id", :content=>"192795788056486"}
     %meta{:name=>"twitter:card", :content=>"summary"}

--- a/source/map.html.haml
+++ b/source/map.html.haml
@@ -1,5 +1,5 @@
 ---
-title: 千葉県サポートマップ（印刷用）
+title: 印刷できる台風災害支援情報マップ（千葉県）
 ---
 - content_for(:header) do
   = stylesheet_link_tag "map"


### PR DESCRIPTION
replaced _千葉県サポート情報_ as _印刷できる台風災害支援情報マップ（千葉県）_.