### PR TITLE
fix for #147 Printable on Print Shortcut

### DIFF
--- a/source/javascripts/mapHelper.ts
+++ b/source/javascripts/mapHelper.ts
@@ -79,12 +79,17 @@ export default class PrintableMap implements IPrintableMap{
     this.map.addControl(new MapboxGL.NavigationControl());
 
     var that = this;
+    var prvious_hash = '';
     this.map.on("moveend", function(){
       that.filterPOIs();
       let bounds = this.getBounds();
       let s = serializeBounds(bounds);
       let path = location.pathname;
-      window.history.pushState('', '', path + '#' + s);
+      if (s != prvious_hash) {
+        window.history.pushState('', '', path + '#' + s);
+      }
+      prvious_hash = s;
+
     });
   }
   filterPOIs(): void{


### PR DESCRIPTION
プリント中にpushStateが行われる事が原因っぽいです。
プリントウィンドウが立ち上がると同時にmoveendが呼ばれ、pushStateが発火する流れのようなので
前回と同様のハッシュの場合、pushStateを更新しない、という流れに変更する事で印刷できるようにしました。

91行目はif文の中でもよかったかも・・・