### PR TITLE
マーカーの色修正、ほかスタイルを調整

### DIFF
--- a/source/javascripts/config.json
+++ b/source/javascripts/config.json
@@ -34,8 +34,8 @@
           "class": "layer_temporary_houses"
         },{
           "name": "携帯充電_ほか",
-          "color": "#9F2951",
-          "bg_color": "#CE9DB9",
+          "color": "#6D4615",
+          "bg_color": "#C1B17E",
           "icon_class": "fas fa-plug",
           "class": "layer_charger"
         },{

--- a/source/javascripts/mapHelper.ts
+++ b/source/javascripts/mapHelper.ts
@@ -149,7 +149,7 @@ export default class PrintableMap implements IPrintableMap{
       if (layer.properties.category.name !== lastCategory){
         // display categories
         $('#list').append('<section id="section-' + layer.properties.category.class + '" class="list-section">' +
-          '<h2 class="list-title"><span class="list-title-mark" style="background-color:' + layer.properties.category.color + '"></span><span>' + layer.properties.category.name + '</span></h2>' +
+          '<h2 class="list-title"><span class="list-title-mark" style="background-color:' + layer.properties.category.color + '"><i class="' + layer.properties.category.iconClass + '"></i></span><span>' + layer.properties.category.name + '</span></h2>' +
           '<ul class="list-items grid-noGutter"></ul>' +
           '</section>');
 

--- a/source/map.html.haml
+++ b/source/map.html.haml
@@ -9,13 +9,13 @@ title: 印刷できる台風災害支援情報マップ（千葉県）
       %button#print 印刷する（A4タテ）
       -#
         / MIERUNE地図は建物が表示されるズームレベルが高すぎるので、利用しないことになった。以下はコメントアウトしている（参照：https://github.com/codeforjapan/mapprint/issues/200）
-        %div.map_controls 
-        %b 地図選択
-        %br
-        %input{:type => "radio", :name => "mapStyle", :id => "color", :value => "color", :checked => true}
-        %label{:for => "color"} カラー
-        %input{:type => "radio", :name => "mapStyle", :id => "mono", :value => "mono"}
-        %label{:for => "mono"} 白黒
+        %div.map_controls
+          %b 地図選択
+          %br
+          %input{:type => "radio", :name => "mapStyle", :id => "color", :value => "color", :checked => true}
+          %label{:for => "color"} カラー
+          %input{:type => "radio", :name => "mapStyle", :id => "mono", :value => "mono"}
+          %label{:for => "mono"} 白黒
     %h2.explain-title-pc このサイトについて
     %div#explain-title.explain-title-sp このサイトについて
     %div#explain-container.explain
@@ -25,7 +25,7 @@ title: 印刷できる台風災害支援情報マップ（千葉県）
         %a{:href=>"https://github.com/codeforjapan/mapprint"} Code for Japan の Github リポジトリ
         から、開発にご参加ください。JavaScript や Leaflet などの経験がある方、大歓迎です。
   %main.sheet.col-12_md-9
-    #header
+    %header#header
       #qrcodecontainer.qrcode
       %div.banner
         %div.logo

--- a/source/scss/_aside.scss
+++ b/source/scss/_aside.scss
@@ -20,6 +20,7 @@
   display: none;
   @include bp(xs) {
     display: block;
+    font-size: $font-size-lg;
   }
 }
 

--- a/source/scss/_header.scss
+++ b/source/scss/_header.scss
@@ -18,6 +18,7 @@
     }
   }
   .datetime {
+    font-size: $font-size-sm;
     text-align: right;
     @include bp(sm) {
       order: -1;

--- a/source/scss/_list.scss
+++ b/source/scss/_list.scss
@@ -9,9 +9,9 @@
 
 .list-title-mark {
   display: inline-block;
-  width: 1.2em;
-  height: 1.2em;
-  line-height: 1.2em;
+  width: 1.2rem;
+  height: 1.2rem;
+  line-height: 1.2rem;
   text-align: center;
   border-radius: 50%;
   margin-right: .5em;

--- a/source/scss/_list.scss
+++ b/source/scss/_list.scss
@@ -9,10 +9,16 @@
 
 .list-title-mark {
   display: inline-block;
-  width: $font-size-base;
-  height: $font-size-base;
+  width: 1.2em;
+  height: 1.2em;
+  line-height: 1.2em;
+  text-align: center;
   border-radius: 50%;
   margin-right: .5em;
+  i {
+    color: #fff;
+    font-size: 80%;
+  }
 }
 
 .list-items {


### PR DESCRIPTION
#201 引き続き修正です

- 充電のマーカーの色を修正
- リストのタイトルにもアイコンを配置
- ヘッダーおよびサイドのタイトルのフォントサイズを調整
