### PR TITLE
GeoJSONの読み込みをサポートする

### DIFF
--- a/assets/config/2021-geojson-test.json
+++ b/assets/config/2021-geojson-test.json
@@ -1,0 +1,58 @@
+{
+  "map_id":"2021-geojson-test",
+  "map_title":"GeoJSON読み込みのテスト",
+  "map_title_en":"Test for loading GeoJSON",
+  "map_description":"",
+  "map_image": null,
+  "sources": [
+    {
+      "id" : "test",
+      "url" : "/geojson/test.geojson",
+      "type" : "geojson",
+      "title" : "Test用GeoJSON",
+      "show" : true
+    }
+  ],
+  "default_hash": "35.034970230243786,139.83536606997205-34.998870264553034,139.90144296563784",
+  "center" : [139.83536606997205, 35.034970230243786],
+  "type":"geojson",
+  "layer_settings":{
+    "GS(赤：無事)":  {
+      "color": "#992222",
+      "bg_color": "#CA9491",
+      "icon_class": "fas fa-heart",
+      "class": "layer_gs_ok"
+    },
+  "GS (黒点：未確認)": {
+      "color": "#4F4F5A",
+      "bg_color": "#B7B7BE",
+      "icon_class": "fas fa-eye-slash",
+      "class": "layer_gs_undefined"
+    },
+  "給水所_(千葉市・県指定除く）": {
+      "color": "#285797",
+      "bg_color": "#A3BBDA",
+      "icon_class": "fas fa-tint",
+      "class": "layer_water_chibacity"
+    },
+  "避難所": {
+      "color": "#276445",
+      "bg_color": "#A4C1B0",
+      "icon_class": "fas fa-street-view",
+      "class": "layer_temporary_houses"
+  },
+  "携帯充電_ほか": {
+      "color": "#6D4615",
+      "bg_color": "#C1B17E",
+      "icon_class": "fas fa-plug",
+      "class": "layer_charger"
+    },
+    "無料Wifi" : {
+      "color": "#604490",
+      "bg_color": "#BDB1D8",
+      "icon_class": "fas fa-wifi",
+      "class": "layer_wifi"
+    }
+  }
+}
+

--- a/lib/MapHelper.ts
+++ b/lib/MapHelper.ts
@@ -78,6 +78,10 @@ export default class MapHelper implements IPrintableMap {
       case "umal":
         this.loadUmapJsonData(data);
         break;
+      case "geojson":
+        const json = JSON.parse(data);
+        return this.loadGeoJSONData(json);
+        break;
     }
   }
 
@@ -107,6 +111,17 @@ export default class MapHelper implements IPrintableMap {
         // this.addMarker(feature, category);
       });
     });
+  }
+
+  loadGeoJSONData(data: any): [any, string] {
+    let updated_at = Date.now().toLocaleString();
+    let markers = [];
+    console.log(data)
+    data["features"].forEach((feature) => {
+      const category = feature["category"];
+      markers.push({feature, category});
+    });
+    return [markers, updated_at];
   }
 
   loadKMLData(data: Document, layer_setting:any, updated_search_key?:UpdatedSearchKey): [any, string] {

--- a/static/geojson/test.geojson
+++ b/static/geojson/test.geojson
@@ -1,0 +1,21 @@
+{
+"type": "FeatureCollection",
+"name": "ghp_D",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::6668" } },
+"features": [
+{ "type": "Feature", "properties": { "latitude": 35.936056, "longitude": 139.567829, "address": "日本、〒331-0077 埼玉県さいたま市西区中釘１４３８−２", "name": null, "name:en": null }, "geometry": { "type": "Point", "coordinates": [ 139.567829, 35.936056 ] } },
+{ "type": "Feature", "properties": { "latitude": 35.989333, "longitude": 139.590853, "address": "日本、〒362-0005 埼玉県上尾市西門前６４７−４", "name": null, "name:en": null }, "geometry": { "type": "Point", "coordinates": [ 139.590853, 35.989333 ] } },
+{ "type": "Feature", "properties": { "latitude": 35.729583, "longitude": 139.791365, "address": "日本、〒110-0003 東京都台東区根岸５丁目１９−６ 三ノ輪駅", "name": null, "name:en": null }, "geometry": { "type": "Point", "coordinates": [ 139.791365, 35.729583 ] } },
+{ "type": "Feature", "properties": { "latitude": 40.92408, "longitude": 140.451989, "address": "日本、〒037-0201 青森県五所川原市金木町川倉七夕野４０−１０", "name": null, "name:en": null }, "geometry": { "type": "Point", "coordinates": [ 140.451989, 40.92408 ] } },
+{ "type": "Feature", "properties": { "latitude": 35.762605, "longitude": 139.592008, "address": "日本、〒178-0061 東京都練馬区大泉学園町１丁目２０−１２", "name": null, "name:en": null }, "geometry": { "type": "Point", "coordinates": [ 139.592008, 35.762605 ] } },
+{ "type": "Feature", "properties": { "latitude": 35.840668, "longitude": 139.53774, "address": "日本、〒354-0025 埼玉県富士見市関沢２丁目２５−４", "name": null, "name:en": null }, "geometry": { "type": "Point", "coordinates": [ 139.53774, 35.840668 ] } },
+{ "type": "Feature", "properties": { "latitude": 35.765356, "longitude": 139.492103, "address": "日本、〒189-0002 東京都東村山市青葉町２丁目４０−１", "name": null, "name:en": null }, "geometry": { "type": "Point", "coordinates": [ 139.492103, 35.765356 ] } },
+{ "type": "Feature", "properties": { "latitude": 35.756952, "longitude": 139.535516, "address": "日本、〒203-0053 東京都東久留米市本町１丁目１０−７", "name": "東久留米", "name:en": "Higashi Kurume" }, "geometry": { "type": "Point", "coordinates": [ 139.535516, 35.756952 ] } },
+{ "type": "Feature", "properties": { "latitude": 35.94034, "longitude": 139.646552, "address": "日本、〒337-0051 埼玉県さいたま市見沼区東大宮７丁目６５−８", "name": "マルエツ大宮砂町", "name:en": "Maruetsu oomiya sunamachi" }, "geometry": { "type": "Point", "coordinates": [ 139.646552, 35.94034 ] } },
+{ "type": "Feature", "properties": { "latitude": 36.219689, "longitude": 139.667009, "address": "Unnamed Road, 藤岡町内野 栃木市 栃木県 323-1103 日本", "name": "渡良瀬遊水池", "name:en": "Watarase Lake" }, "geometry": { "type": "Point", "coordinates": [ 139.667009, 36.219689 ] } },
+{ "type": "Feature", "properties": { "latitude": 36.122848, "longitude": 139.595639, "address": "日本、〒347-0045 埼玉県加須市富士見町２−１８", "name": "加須駅", "name:en": "Kazo Station" }, "geometry": { "type": "Point", "coordinates": [ 139.595639, 36.122848 ] } },
+{ "type": "Feature", "properties": { "latitude": 36.568138, "longitude": 139.7552, "address": "日本、〒322-0034 栃木県鹿沼市府中町１９４−５", "name": "梅沢歯科", "name:en": "Umezawa Dental Clinic" }, "geometry": { "type": "Point", "coordinates": [ 139.7552, 36.568138 ] } },
+{ "type": "Feature", "properties": { "latitude": 35.844767, "longitude": 139.654777, "address": "日本、〒336-0022 埼玉県さいたま市南区白幡３丁目１−３４ 白幡公園", "name": "白幡公園", "name:en": "Shirahata Park" }, "geometry": { "type": "Point", "coordinates": [ 139.654777, 35.844767 ] } },
+{ "type": "Feature", "properties": { "latitude": 35.793695, "longitude": 139.682442, "address": "日本、〒174-0041 東京都板橋区舟渡３丁目７−６", "name": "アディア", "name:en": "Adia" }, "geometry": { "type": "Point", "coordinates": [ 139.682442, 35.793695 ] } }
+]
+}


### PR DESCRIPTION
# 概要
- `/assets/config/*.json` で指定するデータ形式に `geojson` を追加し、GeoJSON形式のデータを読み込めるようにする

# 背景
- 多言語に対応したい
- 現在の紙マップはKMLによるデータ読み込みがメインだが、KMLは多言語を想定していない
- GeoJSONのほうが柔軟にデータ構造を変えられて、多言語の情報を埋め込める

# 動作確認範囲
- `/assets/config/list.json` に `2021-geojson-test.json` を追加する
- npm run devで開発サーバーを立ち上げる
- http://localhost:3000/map/2021-geojson-test でマーカーが表示される

# スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/9894a0a224ee3f698dbbb0ff343d79b9.jpg)](https://gyazo.com/9894a0a224ee3f698dbbb0ff343d79b9)