### PR TITLE
GeoJSONおよび英語関係の微修正

### DIFF
--- a/components/PrintableMap.vue
+++ b/components/PrintableMap.vue
@@ -18,9 +18,11 @@
                   div.popup-type
                     i(:class="[map_config.layer_settings[marker.category].icon_class, map_config.layer_settings[marker.category].class]" :style="{backgroundColor:map_config.layer_settings[marker.category].color}")
                     span.popup-poi-type
-                      | {{marker.category}}
-                  p
+                      | {{getCategoryText(marker.category, $i18n.locale)}}
+                  p(v-if="$i18n.locale === 'ja'")
                     | {{$i18n.t("PrintableMap.name")}} {{marker.feature.properties.name}}
+                  p(v-else)
+                    | {{$i18n.t("PrintableMap.name")}} {{marker.feature.properties["name:en"]}}
                   div.popup-detail-content
                     p(v-html="marker.feature.properties.description ? marker.feature.properties.description : ''")
       .legend-navi
@@ -68,7 +70,8 @@
             ul.list-items.grid-noGutter
               li.col-12_xs-6(v-for="marker in group.markers")
                 span.item-number {{inBoundsMarkers.indexOf(marker) +1}}
-                span.item-name {{marker.feature.properties.name}}
+                span.item-name(v-if="$i18n.locale === 'ja'") {{marker.feature.properties.name}}
+                span.item-name(v-else) {{marker.feature.properties["name:en"]}}}
           .list-section-none(v-if="isDisplayAllCategory && displayMarkersGroupByCategory.length === 0")
             p
               | {{$t("PrintableMap.no_point_in_map")}}
@@ -251,7 +254,13 @@ export default {
     },
     selectCategory (category) {
       this.activeCategory = category
-    }
+    },
+    getCategoryText (category, locale) {
+      if (locale === 'ja') {
+        return this.map_config.layer_settings[category].name
+      } else {
+        return this.map_config.layer_settings[category].name_en
+      }
   }
 }
 </script>

--- a/lib/MapHelper.ts
+++ b/lib/MapHelper.ts
@@ -118,7 +118,7 @@ export default class MapHelper implements IPrintableMap {
     let markers = [];
     console.log(data)
     data["features"].forEach((feature) => {
-      const category = feature["category"];
+      const category = feature.properties["category"];
       markers.push({feature, category});
     });
     return [markers, updated_at];

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -79,7 +79,10 @@ export default {
     routes () {
       const list = require('./assets/config/list.json')
       return list.map((name) => {
-        return '/map/' + name.replace('.json', '')
+        return [
+          '/map/' + name.replace('.json', ''),
+          '/en/map/' + name.replace('.json', '')
+        ]
       })
     },
     fallback: true


### PR DESCRIPTION
# 概要
- `npm run generate` で、パス `/en/map/:mapid` も `./dist` 以下に生成する
- GeoJSONを読み込む際、categoryはpropertiesから読み込む
- `PrintableMap.vue` で場所名を表示する際に多言語を考慮して分岐する