### PR TITLE
add docker-compose.yml & docker-compose.dev.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:14
+RUN mkdir /app
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY ./ ./
+RUN npm run build && npm run generate
+ENV PORT=5000
+EXPOSE 5000
+CMD npm run start

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,6 @@
+FROM node:14
+RUN mkdir /app
+WORKDIR /app
+ENV PORT=5000
+EXPOSE 5000
+CMD npm ci && npm run dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  dev: 
+    build: 
+      context: ./
+      dockerfile: Dockerfile.dev
+    ports:
+      - ${PORT:-5000}:${PORT:-5000}
+    environment:
+      - NUXT_HOST=0.0.0.0
+      - PORT=${PORT:-5000}
+    volumes:
+      - ./:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  nuxt: 
+    build: 
+      context: ./
+    ports:
+      - ${PORT:-5000}:${PORT:-5000}
+    environment:
+      - NUXT_HOST=0.0.0.0
+      - PORT=${PORT:-5000}


### PR DESCRIPTION
make it easy for anyone to start the development environment.

```
$ docker-compose -f docker-compose.dev.yml up
```

To reduce trouble, I'm making a trade-off for startup time. `npm ci` is executed every time at startup.

ref. #316 