### PR TITLE
ESLint を Github Actions で実行する

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,11 @@ module.exports = {
   // add your custom rules here
   rules: {
     quotes: ['error', 'single'],
+    camelcase: 'warn',
+    'vue/no-mutating-props': 'warn',
+    'brace-style': 'warn',
+    'eqeqeq': 'warn',
+    'quotes': 'warn',
     semi: 'error'
   }
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: lint
+on: push
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm ci
+      - run: npm run lint
+

--- a/static/ga.js
+++ b/static/ga.js
@@ -1,5 +1,5 @@
 window.dataLayer = window.dataLayer || []
-function gtag () { dataLayer.push(arguments) }
+function gtag () { window.dataLayer.push(arguments) }
 gtag('js', new Date())
 gtag('config', 'UA-45275834-9')
 window.addEventListener('afterprint', function () {


### PR DESCRIPTION
壊れていたり eslint が怒ったりするコードがマージされがち。
とりあえず CI で毎回実行したほうが安全でいいと思う。