### PR TITLE
GitHub Actions gh-pages を直す

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,7 +31,7 @@ jobs:
       run: npm test
 
     - name: generate
-      run: npm run generate
+      run: npm run generate --fail-on-error
 
     - name: deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -84,7 +84,7 @@ export default {
           '/en/map/' + name.replace('.json', '')
         ]
       })
-      return mapped
+      return [].concat(...mapped)
     },
     fallback: true
   },


### PR DESCRIPTION
# 概要
- nuxt.config.js の generate.routes() が壊れていたのを修正
- npm run generate --fail-on-errorで、失敗したらActionをfailにするように指定

# 動作確認
- npm run generateが動くこと

Before
[![Image from Gyazo](https://i.gyazo.com/c0de00032d06e90134d77d446e3492ac.png)](https://gyazo.com/c0de00032d06e90134d77d446e3492ac)

After
[![Image from Gyazo](https://i.gyazo.com/83f74bed674ec2584f870c198c2e8836.png)](https://gyazo.com/83f74bed674ec2584f870c198c2e8836)