### PR TITLE
github pagesを生成するactionのnodeバージョンをDockerに揃える

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
     - name: setup node
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '14.16.0'
 
     - name: Cache dependencies
       uses: actions/cache@v1


### PR DESCRIPTION
#330 で node-sass が sass に置き換えられたので動くはず