### PR TITLE
nuxtコマンドがnode_modulesの中身までwatchするので超重くなる問題の修正

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -114,5 +114,10 @@ export default {
         }
       }
     }
+  },
+  watchers: {
+    webpack: {
+      ignored: /node_modules/
+    }
   }
 }


### PR DESCRIPTION
Linuxでnuxtコマンドを実行するとFile watchの限界に達して怒られる。
nuxt.config.jsに以下を追記してnode_modulesの中身はwatchしないようにする。
```
  watchers: {
    webpack: {
      ignored: /node_modules/
    }
  }
```