### PR TITLE
カテゴリ名の多言語対応

### DIFF
--- a/assets/config/2021-geojson-test.json
+++ b/assets/config/2021-geojson-test.json
@@ -19,8 +19,6 @@
   "type":"geojson",
   "layer_settings":{
     "未分類": {
-      "name": "未分類",
-      "name_en": "Not categorized",
       "class": "layer_not_categorized",
       "color": "#C0C0C0",
       "bg_color": "#808080"
@@ -34,24 +32,18 @@
       "class": "layer_temporary_houses"
     },
     "給水所":  {
-      "name": "給水所",
-      "name_en": "Water Supply Office",
       "color": "#001D96",
       "bg_color": "#1CA3EA",
       "icon_class": "fas fa-tint",
       "class": "layer_water"
     },
     "入浴施設": {
-      "name": "入浴施設",
-      "name_en": "Bathing facilities",
       "color": "#c43895",
       "bg_color": "#f9b3e2",
       "icon_class": "fas fa-shower",
       "class": "layer_shower"
     },
     "携帯充電": {
-      "name": "携帯充電",
-      "name_en": "Cell phone charging",
       "color": "#6D4615",
       "bg_color": "#C1B17E",
       "icon_class": "fas fa-plug",

--- a/components/PrintableMap.vue
+++ b/components/PrintableMap.vue
@@ -136,7 +136,6 @@ export default {
     },
     displayMarkersGroupByCategory () {
       const resultGroupBy = this.inBoundsMarkers.reduce((groups, current) => {
-        const config = this.map_config.layer_settings[current.category]
         let group = groups.find(g => g.category === current.category)
         if (!group) {
           group = {
@@ -248,8 +247,8 @@ export default {
       if (category === undefined) {
         category = "未分類"
       }
-      const key = 'category.'+category;
-      let categoryText = this.$i18n.t(key)
+      const key = 'category.' + category
+      const categoryText = this.$i18n.t(key)
       if (categoryText !== key) {
         return categoryText
       } else {

--- a/components/PrintableMap.vue
+++ b/components/PrintableMap.vue
@@ -64,12 +64,11 @@
                 .legend-navi-button
                   img.legend-navi-img(:src='legendActive' width="40" height="40" :alt='$t("PrintableMap.show_all")')
           .list-outer(:class='{open: isOpenList}')
-            section.list-section(v-for='group in displayMarkersGroupByCategory' :class='{show: isDisplayAllCategory || activeCategory === group.name}')
+            section.list-section(v-for='group in displayMarkersGroupByCategory' :class='{show: isDisplayAllCategory || activeCategory === getMarkerCategoryText(group.category, $i18n.locale)}')
               h2.list-title(:style="{backgroundColor:map_config.layer_settings[group.category].color}")
                 span.list-title-mark
                   i(:class="map_config.layer_settings[group.category].icon_class")
-                span(v-if="$i18n.locale === 'ja'") {{group.name}}
-                span(v-else) {{group.name_en}}
+                span {{getMarkerCategoryText(group.category, $i18n.locale)}}
               ul.list-items.grid-noGutter
                 li.col-12_xs-6(v-for="marker in group.markers")
                   span.item-number {{inBoundsMarkers.indexOf(marker) +1}}
@@ -138,12 +137,10 @@ export default {
     displayMarkersGroupByCategory () {
       const resultGroupBy = this.inBoundsMarkers.reduce((groups, current) => {
         const config = this.map_config.layer_settings[current.category]
-        let group = groups.find(g => g.name === current.category)
+        let group = groups.find(g => g.category === current.category)
         if (!group) {
           group = {
             category: current.category,
-            name: config.name,
-            name_en: config.name_en,
             prop: current.category,
             markers: []
           }
@@ -248,10 +245,21 @@ export default {
       window.print()
     },
     getMarkerCategoryText (category, locale) {
-      if (locale === 'ja') {
-        return this.map_config.layer_settings[category].name
+      if (category === undefined) {
+        category = "未分類"
+      }
+      console.log(category)
+      const key = 'category.'+category;
+      let categoryText = this.$i18n.t(key)
+      console.log('categoryText:'+categoryText)
+      if (categoryText !== key) {
+        return categoryText
       } else {
-        return this.map_config.layer_settings[category].name_en
+        if (locale === 'ja') {
+          return this.map_config.layer_settings[category].name
+        } else {
+          return this.map_config.layer_settings[category].name_en
+        }
       }
     },
     getMarkerNameText (markerProperties, locale) {

--- a/components/PrintableMap.vue
+++ b/components/PrintableMap.vue
@@ -248,18 +248,12 @@ export default {
       if (category === undefined) {
         category = "未分類"
       }
-      console.log(category)
       const key = 'category.'+category;
       let categoryText = this.$i18n.t(key)
-      console.log('categoryText:'+categoryText)
       if (categoryText !== key) {
         return categoryText
       } else {
-        if (locale === 'ja') {
-          return this.map_config.layer_settings[category].name
-        } else {
-          return this.map_config.layer_settings[category].name_en
-        }
+        return category
       }
     },
     getMarkerNameText (markerProperties, locale) {

--- a/lib/MapHelper.ts
+++ b/lib/MapHelper.ts
@@ -109,7 +109,7 @@ export default class MapHelper implements IPrintableMap {
     let markers = [];
     data["features"].forEach((feature) => {
       let category = "未分類"
-      if (feature.property["category"]) {
+      if (feature.properties["category"]) {
         category = feature.properties["category"];
       }
       markers.push({feature, category});

--- a/locales/en.json
+++ b/locales/en.json
@@ -28,5 +28,15 @@
     "no_point_in_map": "None of the points are present on the map being displayed",
     "close_list": "Close list",
     "map_url": "https://tile.openstreetmap.jp/styles/maptiler-basic-en/{z}/{x}/{y}.png"
+  },
+  "category": {
+    "未分類": "Not categorized",
+    "避難所": "Shelter",
+    "自主避難所": "Voluntary shelter",
+    "給水所": "Water Supply Office",
+    "入浴施設": "Bathing facilities",
+    "携帯充電": "Cell phone charging",
+    "無料Wi-Fi": "Free Wi-Fi",
+    "ガソリンスタンド": "Gas station"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,5 +1,7 @@
 {
   "common": {
+    "site_name": null,
+    "site_desc": null,
     "about": "Sobre este sitio web",
     "contribute": "Bienvenido a contribuir",
     "title": "Mapa de Papel para información de mapa imprimible"
@@ -25,5 +27,15 @@
     "no_point_in_map": "Ninguno de los puntos existe en el mapa mostrado",
     "close_list": "Cerrar lista",
     "map_url": "https://tile.openstreetmap.jp/styles/maptiler-basic-ja/{z}/{x}/{y}.png"
+  },
+  "category": {
+    "未分類": null,
+    "避難所": null,
+    "自主避難所": null,
+    "給水所": null,
+    "入浴施設": null,
+    "携帯充電": null,
+    "無料Wi-Fi": null,
+    "ガソリンスタンド": null
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -28,5 +28,15 @@
     "no_point_in_map": "表示中のマップにはどのポイントも存在しません",
     "close_list": "リストを閉じる",
     "map_url": "https://tile.openstreetmap.jp/styles/maptiler-basic-ja/{z}/{x}/{y}.png"
+  },
+  "category": {
+    "未分類": "未分類",
+    "避難所": "避難所",
+    "自主避難所": "自主避難者",
+    "給水所": "給水所",
+    "入浴施設": "入浴施設",
+    "携帯充電": "携帯充電",
+    "無料Wi-Fi": "無料Wi-Fi",
+    "ガソリンスタンド": "ガソリンスタンド"
   }
 }

--- a/locales/tw.json
+++ b/locales/tw.json
@@ -1,5 +1,7 @@
 {
   "common": {
+    "site_name": null,
+    "site_desc": null,
     "about": "關於這個網站",
     "contribute": "歡迎貢獻",
     "title": "可列印的紙本地圖資訊站"
@@ -26,5 +28,15 @@
     "no_point_in_map": "正在顯示的地圖中沒有任何點位",
     "close_list": "關閉列表",
     "map_url": "https://tile.openstreetmap.jp/styles/maptiler-basic-en/{z}/{x}/{y}.png"
+  },
+  "category": {
+    "未分類": null,
+    "避難所": null,
+    "自主避難所": null,
+    "給水所": null,
+    "入浴施設": null,
+    "携帯充電": null,
+    "無料Wi-Fi": null,
+    "ガソリンスタンド": null
   }
 }


### PR DESCRIPTION
# 概要
- カテゴリ名がlocales以下のファイルにないと、翻訳に協力してもらいにくい
- とりあえず、主要なカテゴリ名を翻訳できるようにする
- 過去のmapprintではカテゴリ名が自由な感じで決められていて翻訳が難しい
- 今後のmapprintではカテゴリ名を事前に決めたものを使うようにしたい
- 現実的な入力や管理のしやすさを考慮して、日本語名を主とする
- カテゴリ名の翻訳がない場合は日本語を表示する

以下のカテゴリ名を定義した
- 未分類
- 避難所
- 自主避難所
- 給水所
- 入浴施設
- 携帯充電
- 無料Wi-Fi
- ガソリンスタンド