### PR TITLE
最新の @nuxt/types を使うように修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     },
     "types": [
       "@types/node",
-      "@nuxt/types@0.7.9+"
+      "@nuxt/types@"
     ]
   },
   "exclude": [


### PR DESCRIPTION
#371 と #372 の変更で最新の `@nuxt/types` を使っても平気になったのでワークアラウンドとしてバージョン指定を行っていた部分を削除しました。

see also. #334