### PR TITLE
凡例が表示されなくなってしまったのを修正する

### DIFF
--- a/components/PrintableMap.vue
+++ b/components/PrintableMap.vue
@@ -57,8 +57,8 @@
               .legend-list-outer
                 simplebar(data-simplebar-auto-hide="false")
                   ul.legend-list
-                    li.legend-item(v-for='(setting, name) in map_config.layer_settings' v-if="displayMarkersGroupByCategory.some((elm) => elm.name === name)")
-                      span.legend-mark(:style="{backgroundColor:setting.color}" @click="selectCategory(name), isOpenList=name, isDisplayAllCategory=false" :class='{open: isDisplayAllCategory || activeCategory === name}')
+                    li.legend-item(v-for='(setting, category) in map_config.layer_settings' v-if="displayMarkersGroupByCategory.some((elm) => elm.category === category)")
+                      span.legend-mark(:style="{backgroundColor:setting.color}" @click="selectCategory(category), isOpenList=category, isDisplayAllCategory=false" :class='{open: isDisplayAllCategory || activeCategory === category}')
                         i(:class="[setting.icon_class]")
               .legend-navi-icon(@click="selectCategory(''), isDisplayAllCategory=true, isOpenList=true" :class='{active: activeCategory}')
                 .legend-navi-button


### PR DESCRIPTION
# 概要
- FIX: #378
- カテゴリ名の構造をいじったせいで凡例表示機能が壊れてしまっていたのを直す

# 動作確認
- `yarn run dev` して動くことを確認した

# スクリーンショット
## After
[![Image from Gyazo](https://i.gyazo.com/b5d4b3c1ceac30d1580ce65ae7f909e2.png)](https://gyazo.com/b5d4b3c1ceac30d1580ce65ae7f909e2)

## Before
[![Image from Gyazo](https://i.gyazo.com/b5b1c2a0f5bca0b09e5e8b071a24aedf.png)](https://gyazo.com/b5b1c2a0f5bca0b09e5e8b071a24aedf)