### PR TITLE
翻訳エラーをいちいちコンソールに出さない

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -67,6 +67,12 @@ export default {
   ** See https://axios.nuxtjs.org/options
   */
   axios: {},
+
+  i18n: {
+    vueI18n: {
+      silentTranslationWarn: true
+    }
+  },
   /*
   ** Build configuration
   */


### PR DESCRIPTION
コンソールが重くなりすぎてエラーでてることの弊害のほうが大きいと思う

FIX: #381