### PR TITLE
静岡県熱海市伊豆山で発生した土砂災害に関する災害情報地図を追加

### DIFF
--- a/assets/config/2021-shizuoka-izusan.json
+++ b/assets/config/2021-shizuoka-izusan.json
@@ -41,6 +41,14 @@
       "icon_class": "fas fa-tint",
       "class": "layer_water"
     },
+    "通行止め":  {
+      "name": "通行止め",
+      "name_en": "Road closed",
+      "color": "#ff0000",
+      "bg_color": "#ff0080",
+      "icon_class": "fas fa-ban",
+      "class": "layer_water"
+    },
     "入浴施設": {
       "name": "入浴施設",
       "name_en": "Bathing facility",

--- a/assets/config/2021-shizuoka-izusan.json
+++ b/assets/config/2021-shizuoka-izusan.json
@@ -1,0 +1,53 @@
+{
+  "map_id":"2021-shizuoka-izusan",
+  "map_title":"2021年 静岡県熱海市伊豆山 土砂崩れ 災害支援情報",
+  "map_title_en":"2021 Landslide at Izusan, Atami, Shizuoka",
+  "map_description":"",
+  "map_image": null,
+  "sources": [
+    {
+      "id" : "shizuoka-izusan",
+      "url" : "https://script.google.com/macros/s/AKfycbw0D0AjIFPBGbBXj3Zr5X1j_34fwIj8RSflwc6EJrDp97pMdRRnyNcMOOHvuRHZOslJdg/exec?confirmed=true",
+      "type" : "geojson",
+      "title" : "2021年 静岡県熱海市伊豆山 土砂崩れ 災害支援情報",
+      "title_en" : "2021 Landslide at Izusan, Atami, Shizuoka",
+      "show" : true
+    }
+  ],
+  "default_hash": "35.15658910678265,138.91779233722173-35.08428585053625,139.2314565974297",
+  "center" : [139.055633, 35.1208872],
+  "type":"geojson",
+  "layer_settings":{
+    "未分類": {
+      "name": "未分類",
+      "name_en": "Not categorized",
+      "class": "layer_not_categorized",
+      "color": "#C0C0C0",
+      "bg_color": "#808080"
+    },
+    "避難所": {
+      "name": "避難所",
+      "name_en": "Shelter",
+      "color": "#276445",
+      "bg_color": "#A4C1B0",
+      "icon_class": "fas fa-street-view",
+      "class": "layer_shelter"
+    },
+    "給水所":  {
+      "name": "給水所",
+      "name_en": "Water supply station",
+      "color": "#001D96",
+      "bg_color": "#1CA3EA",
+      "icon_class": "fas fa-tint",
+      "class": "layer_water"
+    },
+    "入浴施設": {
+      "name": "入浴施設",
+      "name_en": "Bathing facility",
+      "color": "#c43895",
+      "bg_color": "#f9b3e2",
+      "icon_class": "fas fa-shower",
+      "class": "layer_shower"
+    }
+  }
+}

--- a/assets/config/2021-shizuoka-izusan.json
+++ b/assets/config/2021-shizuoka-izusan.json
@@ -1,6 +1,6 @@
 {
   "map_id":"2021-shizuoka-izusan",
-  "map_title":"2021年 静岡県熱海市伊豆山 土砂崩れ 災害支援情報",
+  "map_title":"2021年 静岡県熱海市伊豆山 土砂崩れ 災害情報",
   "map_title_en":"2021 Landslide at Izusan, Atami, Shizuoka",
   "map_description":"",
   "map_image": null,
@@ -9,7 +9,7 @@
       "id" : "shizuoka-izusan",
       "url" : "https://script.google.com/macros/s/AKfycbw0D0AjIFPBGbBXj3Zr5X1j_34fwIj8RSflwc6EJrDp97pMdRRnyNcMOOHvuRHZOslJdg/exec?confirmed=true",
       "type" : "geojson",
-      "title" : "2021年 静岡県熱海市伊豆山 土砂崩れ 災害支援情報",
+      "title" : "2021年 静岡県熱海市伊豆山 土砂崩れ 災害情報",
       "title_en" : "2021 Landslide at Izusan, Atami, Shizuoka",
       "show" : true
     }

--- a/assets/config/2021-shizuoka-izusan.json
+++ b/assets/config/2021-shizuoka-izusan.json
@@ -3,6 +3,7 @@
   "map_title":"2021年 静岡県熱海市伊豆山 土砂崩れ 災害情報",
   "map_title_en":"2021 Landslide at Izusan, Atami, Shizuoka",
   "map_description":"",
+  "map_description_en":"",
   "map_image": null,
   "sources": [
     {

--- a/assets/config/2021-shizuoka-izusan.json
+++ b/assets/config/2021-shizuoka-izusan.json
@@ -42,9 +42,17 @@
       "icon_class": "fas fa-tint",
       "class": "layer_water"
     },
-    "通行止め":  {
-      "name": "通行止め",
+    "車両通行止め":  {
+      "name": "車両通行止め",
       "name_en": "Road closed",
+      "color": "#ff0000",
+      "bg_color": "#ff0080",
+      "icon_class": "fas fa-ban",
+      "class": "layer_water"
+    },
+    "鉄道運行見合わせ":  {
+      "name": "鉄道運行見合わせ",
+      "name_en": "Railway operation suspension",
       "color": "#ff0000",
       "bg_color": "#ff0080",
       "icon_class": "fas fa-ban",

--- a/assets/config/list.json
+++ b/assets/config/list.json
@@ -1,4 +1,5 @@
 [
   "2019-typhoon-19.json",
-  "2019-chiba-typhoon-15.json"
+  "2019-chiba-typhoon-15.json",
+  "2021-shizuoka-izusan.json"
 ]

--- a/pages/map/_map.vue
+++ b/pages/map/_map.vue
@@ -105,6 +105,9 @@ export default {
     const image = this.map_config.map_image ? this.map_config.map_image : 'logo.png'
     switch (this.$i18n.locale) {
       case 'ja':
+        title = this.map_config.map_title
+        description = this.map_config.map_description
+        break
       case 'en':
         title = this.map_config.map_title_en
         description = this.map_config.map_description_en


### PR DESCRIPTION
2021/07/03に静岡県熱海市伊豆山で土砂災害が発生しました。

多数の被災者が発生しており、ガス、水道などのライフラインにも影響が出ています。
紙マップによって災害支援情報を収集し公開したいと思います。

以下のGoogle Spreadsheetに入力されたデータをGeoJSONに変換して表示しています。
https://docs.google.com/spreadsheets/d/1u5rXVPCfclPYmu3SYNRxI6ZkT17LI4Ao_DNVu02eNck/edit#gid=1539080418

とりあえず何箇所か避難所情報を入力してみて、ローカル開発環境では動くことを確認できてます
[![Image from Gyazo](https://i.gyazo.com/e0f0adb3600802336842ba005671fb0e.png)](https://gyazo.com/e0f0adb3600802336842ba005671fb0e)