### PR TITLE
モバイル版での表示崩れを修正

### DIFF
--- a/assets/sass/_sub.scss
+++ b/assets/sass/_sub.scss
@@ -1,8 +1,13 @@
 .sub-outer {
-  display: grid;
-  grid-template-columns: 2fr 2fr;
-  justify-content: center;
-  width: 40%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  @include bp(md) {
+    display: grid;
+    grid-template-columns: 2fr 2fr;
+    justify-content: center;
+    width: 40%;
+  }
 }
 
 .sub-button {
@@ -13,10 +18,11 @@
   border-radius: 3em;
   text-align: center;
   line-height: 1.1;
-  padding: .5em 1em;
-  margin-left: 1em;
-  margin-bottom: 0.5em;
+  margin: 0.5em 1em 0.5em 0;
   @include bp(md) {
+    padding: .5em 1em;
+    margin-left: 1em;
+    margin-bottom: 0.5em;
     box-shadow: 2px 2px 5px $color-alpha-black;
   }
   i {


### PR DESCRIPTION
モバイル版での表示崩れを修正しました。  

スマートフォン表示の場合はロゴの横にボタンを表示するのではなく、ヘッダーの下にメニュー行として1行追加し、横並びで表示させるように変更しました。

もし本来の実装意図と異なるようでしたらご指摘ください。m(_ _)m

## スクリーンショット

（自分の手元の環境ではマップ部分が表示されておりません。ご承知ください。）

### iOS

iPhone 12 mini, `Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Mobile/15E148 Safari/604.1`  

![image](https://user-images.githubusercontent.com/39210441/124374755-f23c0b00-dcd8-11eb-87a9-4d8b1354cb28.png)

### Android

Xiaomi Redmi Note 9S, `Mozilla/5.0 (Linux; Android 11; Redmi Note 9S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36`  

![image](https://user-images.githubusercontent.com/39210441/124374804-33ccb600-dcd9-11eb-84e4-3c7eaf14b9c4.png)


FIX: #394 