### PR TITLE
apply `npx sass-migrator division **/*.scss`

### DIFF
--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -1,9 +1,11 @@
+@use "sass:list";
+
 :root {
   height: 100%;
   background-color: $root-background-color;
   box-sizing: $root-box-sizing;
   color: $root-color;
-  font: #{$root-font-size}/#{$root-line-height} $root-font-family;
+  font: list.slash($root-font-size, $root-line-height) $root-font-family;
   @include bp(xs) {
     font-size: calc(1rem + ((1vw - 0.355rem) * 0.3165));
   }

--- a/assets/sass/vendor/gridlex/_gridlex-classes.scss
+++ b/assets/sass/vendor/gridlex/_gridlex-classes.scss
@@ -8,14 +8,14 @@
   box-sizing: border-box;
   display: flex;
   flex-flow: row wrap;
-  margin: 0 (-$gl-gutter/2);
+  margin: 0 (-$gl-gutter*0.5);
 }
 // COLS
 [#{$gl-attributeName}~="#{$gl-colName}"],
 [#{$gl-attributeName}*="#{$gl-colName}-"],
 [#{$gl-attributeName}*="#{$gl-colName}_"]{
   box-sizing: border-box;
-  padding: 0 ($gl-gutter/2) $gl-gutter-vertical;
+  padding: 0 ($gl-gutter*0.5) $gl-gutter-vertical;
   max-width: 100%;
 }
 // JUST "COL" & "COL_"

--- a/assets/sass/vendor/gridlex/_gridlex-mixins.scss
+++ b/assets/sass/vendor/gridlex/_gridlex-mixins.scss
@@ -1,4 +1,6 @@
 // Make the breakpoints
+@use "sass:math";
+
 @mixin bp($breakpoint) {
   $query: map-get($gl-mq-list, $breakpoint);
   @if $query != null {
@@ -15,7 +17,7 @@
       [#{$gl-attributeName}*="#{$grid}-#{$i}"] > [#{$gl-attributeName}~="#{$gl-colName}"],
       [#{$gl-attributeName}*="#{$grid}-#{$i}"] > [#{$gl-attributeName}*="#{$gl-colName}-"],
       [#{$gl-attributeName}*="#{$grid}-#{$i}"] > [#{$gl-attributeName}*="#{$gl-colName}_"] {
-        $fraction: 1 / $i;
+        $fraction: math.div(1, $i);
 
         flex-basis: map-get($gl-colFractions, $fraction);
         max-width: map-get($gl-colFractions, $fraction);

--- a/assets/sass/vendor/gridlex/_gridlex-preprocessing.scss
+++ b/assets/sass/vendor/gridlex/_gridlex-preprocessing.scss
@@ -1,5 +1,7 @@
 // calculate width of one col in %
-$gl-colUnit: (100%/$gl-colCount);
+@use "sass:math";
+
+$gl-colUnit: math.div(100%, $gl-colCount);
 
 // calculate and store nth portions for grid by columns
 $gl-colPortions: (
@@ -14,6 +16,6 @@ $gl-colFractions: (
   0: 0 // Avoid division by zero if $i would start at 0
 );
 @for $i from 1 through $gl-colCount {
-  $fraction: 1 / $i;
+  $fraction: math.div(1, $i);
   $gl-colFractions: map-merge($gl-colFractions, ($fraction: $fraction * 100%));
 }


### PR DESCRIPTION
## 概要 | About

sass 関連の warning に対応しました。
https://sass-lang.com/d/slash-div を確認すると、コマンドで機械的に直せる内容の様子だったので（ https://sass-lang.com/documentation/breaking-changes/slash-div/#automatic-migration ）、コマンド実行を行い、`grid-` で始まっている画面上の場所（トップと /map の画面）を目視チェックしました（サービスのコードに詳しくないですが、恐らく問題ないかと。追試お願いします）。

具体的には以下を実行したのみです。

```
npx sass-migrator division **/*.scss
```

脊髄反射的に対応してしまったので、コードの作法等把握せずに手だけとりあえず動かしてしまいました。~~これからチェックしてみます~~（大丈夫そうかなと思いました）。お役に立てば幸いです。

<!--
- Fix: #xxx
- このPull Requestの目的を説明する
-->

## 動作確認方法 | How to check

<!--
- このPull Requestが正常に動くことを他人が確認できるような手順を書く
- このPull Requestで影響を受ける範囲の動作確認を他人が検証できるような手順を書く
-->

## スクリーンショット | Screenshot

見た目に関してはなし。
`yarn run dev` の出力について置いておきますね。

<!--
- このPull Requestの影響を受ける範囲のスクリーンショットを貼る
- 見た目に影響がない場合は「なし」と書く
-->


### Before

<details>
  <summary>yarn run devの結果</summary>

```
yarn run v1.22.21
$ nuxt

 WARN  mode option is deprecated. You can safely remove it from nuxt.config


 WARN  postcss.plugins option has been moved to postcss.postcssOptions.plugins for aligning postcss-loader format.

ℹ Listening on: http://localhost:3000/
ℹ Preparing project for development
ℹ Initial build may take a while
✔ Builder initialized
✔ Nuxt files generated
ℹ Compiling Client
ℹ Starting type checking service...
ℹ Using 1 worker with 2048MB memory limit
ℹ Compiling Server
DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(100%, $gl-colCount) or calc(100% / $gl-colCount)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
2 │ $gl-colUnit: (100%/$gl-colCount);
  │               ^^^^^^^^^^^^^^^^^
  ╵
    assets/sass/vendor/gridlex/_gridlex-preprocessing.scss 2:15  @import
    assets/sass/vendor/gridlex/_gridlex.scss 6:9                 @import
    assets/sass/styles.scss 5:9                                  root stylesheet

DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1, $i) or calc(1 / $i)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
17 │   $fraction: 1 / $i;
   │              ^^^^^^
   ╵
    assets/sass/vendor/gridlex/_gridlex-preprocessing.scss 17:14  @import
    assets/sass/vendor/gridlex/_gridlex.scss 6:9                  @import
    assets/sass/styles.scss 5:9                                   root stylesheet

DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(-$gl-gutter, 2) or calc(-1 * $gl-gutter / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
11 │   margin: 0 (-$gl-gutter/2);
   │              ^^^^^^^^^^^^^
   ╵
    assets/sass/vendor/gridlex/_gridlex-classes.scss 11:14  @import
    assets/sass/vendor/gridlex/_gridlex.scss 8:9            @import
    assets/sass/styles.scss 5:9                             root stylesheet

DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($gl-gutter, 2) or calc($gl-gutter / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
18 │   padding: 0 ($gl-gutter/2) $gl-gutter-vertical;
   │               ^^^^^^^^^^^^
   ╵
    assets/sass/vendor/gridlex/_gridlex-classes.scss 18:15  @import
    assets/sass/vendor/gridlex/_gridlex.scss 8:9            @import
    assets/sass/styles.scss 5:9                             root stylesheet

DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1, $i) or calc(1 / $i)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
18 │         $fraction: 1 / $i;
   │                    ^^^^^^
   ╵
    assets/sass/vendor/gridlex/_gridlex-mixins.scss 18:20   makeGridByNumber()
    assets/sass/vendor/gridlex/_gridlex-classes.scss 146:1  @import
    assets/sass/vendor/gridlex/_gridlex.scss 8:9            @import
    assets/sass/styles.scss 5:9                             root stylesheet

DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(100%, $gl-colCount) or calc(100% / $gl-colCount)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
2 │ $gl-colUnit: (100%/$gl-colCount);
  │               ^^^^^^^^^^^^^^^^^
  ╵
    assets/sass/vendor/gridlex/_gridlex-preprocessing.scss 2:15  @import
    assets/sass/vendor/gridlex/_gridlex.scss 6:9                 @import
    assets/sass/styles.scss 5:9                                  root stylesheet

DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1, $i) or calc(1 / $i)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
17 │   $fraction: 1 / $i;
   │              ^^^^^^
   ╵
    assets/sass/vendor/gridlex/_gridlex-preprocessing.scss 17:14  @import
    assets/sass/vendor/gridlex/_gridlex.scss 6:9                  @import
    assets/sass/styles.scss 5:9                                   root stylesheet

DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(-$gl-gutter, 2) or calc(-1 * $gl-gutter / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
11 │   margin: 0 (-$gl-gutter/2);
   │              ^^^^^^^^^^^^^
   ╵
    assets/sass/vendor/gridlex/_gridlex-classes.scss 11:14  @import
    assets/sass/vendor/gridlex/_gridlex.scss 8:9            @import
    assets/sass/styles.scss 5:9                             root stylesheet

DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($gl-gutter, 2) or calc($gl-gutter / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
18 │   padding: 0 ($gl-gutter/2) $gl-gutter-vertical;
   │               ^^^^^^^^^^^^
   ╵
    assets/sass/vendor/gridlex/_gridlex-classes.scss 18:15  @import
    assets/sass/vendor/gridlex/_gridlex.scss 8:9            @import
    assets/sass/styles.scss 5:9                             root stylesheet

DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1, $i) or calc(1 / $i)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
18 │         $fraction: 1 / $i;
   │                    ^^^^^^
   ╵
    assets/sass/vendor/gridlex/_gridlex-mixins.scss 18:20   makeGridByNumber()
    assets/sass/vendor/gridlex/_gridlex-classes.scss 146:1  @import
    assets/sass/vendor/gridlex/_gridlex.scss 8:9            @import
    assets/sass/styles.scss 5:9                             root stylesheet

✔ Server: Compiled successfully in 2.89s
✔ Client: Compiled successfully in 3.16s
ℹ No type errors found
ℹ Version: typescript 3.6.5
ℹ Time: 1334ms

[friendly-errors]  WARN  Compiled with 1 warnings


[friendly-errors]  WARN  in ./assets/sass/styles.scss

[friendly-errors] Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
Warning

(2637:5) autoprefixer: IE does not support justify-content on grid containers
[friendly-errors] 
 @ ./assets/sass/styles.scss 4:14-225 15:3-20:5 16:22-233
 @ ./.nuxt/App.js
 @ ./.nuxt/index.js
 @ ./.nuxt/client.js
 @ multi ./node_modules/eventsource-polyfill/dist/browserify-eventsource.js (webpack)-hot-middleware/client.js?reload=true&timeout=30000&ansiColors=&overlayStyles=&path=%2F__webpack_hmr%2Fclient&name=client ./.nuxt/client.js
[friendly-errors] 
ℹ Waiting for file changes
ℹ Memory usage: 472 MB (RSS: 653 MB)
ℹ Listening on: http://localhost:3000/
```

</details>

### After

<details>
  <summary>yarn run devの結果</summary>

```
yarn run v1.22.21
$ nuxt

 WARN  mode option is deprecated. You can safely remove it from nuxt.config


 WARN  postcss.plugins option has been moved to postcss.postcssOptions.plugins for aligning postcss-loader format.

ℹ Listening on: http://localhost:3000/
ℹ Preparing project for development
ℹ Initial build may take a while
✔ Builder initialized
✔ Nuxt files generated
ℹ Compiling Client
ℹ Starting type checking service...
ℹ Using 1 worker with 2048MB memory limit
ℹ Compiling Server
✔ Server: Compiled successfully in 2.84s
✔ Client: Compiled successfully in 3.11s
ℹ No type errors found
ℹ Version: typescript 3.6.5
ℹ Time: 1303ms

[friendly-errors]  WARN  Compiled with 1 warnings


[friendly-errors]  WARN  in ./assets/sass/styles.scss

[friendly-errors] Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
Warning

(2637:5) autoprefixer: IE does not support justify-content on grid containers
[friendly-errors] 
 @ ./assets/sass/styles.scss 4:14-225 15:3-20:5 16:22-233
 @ ./.nuxt/App.js
 @ ./.nuxt/index.js
 @ ./.nuxt/client.js
 @ multi ./node_modules/eventsource-polyfill/dist/browserify-eventsource.js (webpack)-hot-middleware/client.js?reload=true&timeout=30000&ansiColors=&overlayStyles=&path=%2F__webpack_hmr%2Fclient&name=client ./.nuxt/client.js
[friendly-errors] 
ℹ Waiting for file changes
ℹ Memory usage: 470 MB (RSS: 644 MB)
ℹ Listening on: http://localhost:3000/
``` 

</details>
