### PR TITLE
Feature/223 default color for categories

### DIFF
--- a/components/PrintableMap.vue
+++ b/components/PrintableMap.vue
@@ -21,12 +21,12 @@ div
               template(slot="marker")
                 div.marker
                   span(
-                    :style="{background:mapConfig.layer_settings[marker.category]?.color}"
+                    :style="{background:mapConfig.layer_settings[marker.category]?.color||marker.feature.properties['marker-color']||'red'}"
                     :class="{show: isDisplayAllCategory || activeCategory === marker.category}"
                   )
                     i(
                       :class="[mapConfig.layer_settings[marker.category]?.icon_class, mapConfig.layer_settings[marker.category]?.class]"
-                      :style="{backgroundColor:mapConfig.layer_settings[marker.category]?.color}"
+                      :style="{backgroundColor:mapConfig.layer_settings[marker.category]?.color, display:mapConfig.layer_settings[marker.category]?'inline':'none'}"
                     )
                     b.number(
                       :style="{background:mapConfig.layer_settings[marker.category]?.bg_color}"

--- a/components/PrintableMap.vue
+++ b/components/PrintableMap.vue
@@ -21,22 +21,22 @@ div
               template(slot="marker")
                 div.marker
                   span(
-                    :style="{background:mapConfig.layer_settings[marker.category].color}"
+                    :style="{background:mapConfig.layer_settings[marker.category]?.color}"
                     :class="{show: isDisplayAllCategory || activeCategory === marker.category}"
                   )
                     i(
-                      :class="[mapConfig.layer_settings[marker.category].icon_class, mapConfig.layer_settings[marker.category].class]"
-                      :style="{backgroundColor:mapConfig.layer_settings[marker.category].color}"
+                      :class="[mapConfig.layer_settings[marker.category]?.icon_class, mapConfig.layer_settings[marker.category]?.class]"
+                      :style="{backgroundColor:mapConfig.layer_settings[marker.category]?.color}"
                     )
                     b.number(
-                      :style="{background:mapConfig.layer_settings[marker.category].bg_color}"
+                      :style="{background:mapConfig.layer_settings[marker.category]?.bg_color}"
                     ) {{inBoundsMarkers.indexOf(marker) + 1}}
               MglPopup
                 div
                   div.popup-type
                     i(
-                      :class="[mapConfig.layer_settings[marker.category].icon_class, mapConfig.layer_settings[marker.category].class]"
-                      :style="{backgroundColor:mapConfig.layer_settings[marker.category].color}"
+                      :class="[mapConfig.layer_settings[marker.category]?.icon_class, mapConfig.layer_settings[marker.category]?.class]"
+                      :style="{backgroundColor:mapConfig.layer_settings[marker.category]?.color}"
                     )
                     span.popup-poi-type
                       | {{getMarkerCategoryText(marker.category, $i18n.locale)}}
@@ -117,11 +117,11 @@ div
             :class='{show: isDisplayAllCategory || activeCategory === getMarkerCategoryText(group.category, $i18n.locale)}'
           )
             h2.list-title(
-              :style="{backgroundColor:mapConfig.layer_settings[group.category].color}"
+              :style="{backgroundColor:mapConfig.layer_settings[group.category]?.color}"
             )
               span.list-title-mark
                 i(
-                  :class="mapConfig.layer_settings[group.category].icon_class"
+                  :class="mapConfig.layer_settings[group.category]?.icon_class"
                 )
               span {{getMarkerCategoryText(group.category, $i18n.locale)}}
             ul.list-items.grid-noGutter

--- a/lib/MapHelper.ts
+++ b/lib/MapHelper.ts
@@ -139,7 +139,7 @@ export default class MapHelper implements IPrintableMap {
     }
     let markers = [];
     Array.prototype.forEach.call(folders, (folder) => {
-      let category = readCategoryOfFolder(folder, data).name;
+      let category = readCategoryOfFolder(folder, data);
 
       if (tj.kml(folder).type == "FeatureCollection") {
         let geojsondata: geoJson.FeatureCollection = tj.kml(folder, {styles: true});
@@ -147,14 +147,16 @@ export default class MapHelper implements IPrintableMap {
           //that.addFeatureCollection(geojsondata, category);
           const result =  geojsondata.features.map((feature: geoJson.Feature) => {
             if (feature.geometry.type == "Point") {
-              markers.push({feature, category});
+              feature.properties['marker-color'] = category.color;
+              markers.push({feature, category: category.name});
             }
           });
           return result;
         }
       } else {
         let geojsondata: geoJson.Feature = tj.kml(folder, {styles: true});
-        markers.push({geojsondata, category});
+        geojsondata.properties['marker-color'] = category.color;
+        markers.push({geojsondata, category: category.name});
       }
     });
     return [markers, updated_at];
@@ -229,7 +231,12 @@ export function readCategoryOfFolder(folder:Element, document:Document):Category
             let styleUrl = elem.querySelector("styleUrl").textContent;
             let style = document.querySelector(styleUrl);
             try{
-              color = "#" + style.querySelector("IconStyle color").textContent.substr(0,6); // dirty fix
+              const c: String = style.querySelector("IconStyle color").textContent;
+              const a = parseInt('0x'+c.substring(0,2))
+              const b = parseInt('0x'+c.substring(2,4))
+              const g = parseInt('0x'+c.substring(4,6))
+              const r = parseInt('0x'+c.substring(6,8))
+              color = `rgba(${r},${g},${b},${a})`
             }catch(e){
               color = DEFAULT_ICON_COLOR;
             }

--- a/lib/MapHelper.ts
+++ b/lib/MapHelper.ts
@@ -232,7 +232,7 @@ export function readCategoryOfFolder(folder:Element, document:Document):Category
             let style = document.querySelector(styleUrl);
             try{
               const c: String = style.querySelector("IconStyle color").textContent;
-              const a = parseInt('0x'+c.substring(0,2))
+              const a = parseInt('0x'+c.substring(0,2)) / 255
               const b = parseInt('0x'+c.substring(2,4))
               const g = parseInt('0x'+c.substring(4,6))
               const r = parseInt('0x'+c.substring(6,8))


### PR DESCRIPTION
## 概要 | About

- Fix #223
- https://github.com/codeforjapan/mapprint/blob/master/lib/MapHelper.ts#L232 を修正した。KMLのIconStyle color (16進のabgr) を CSS の 10進 rgba に合わせた。

## 動作確認方法 | How to check

- yarn install && yarn run dev
- 2019-typhoon-19 (2019年台風19号災害支援情報マップ全国版) を開く
- `/map/2019-typhoon-19#35.61450894133367,140.26920449529035-35.57591007410696,140.35045014889408` へ移動する
- 東金市外三市町清掃組合 が 「桃」で表示される
- 八街市二州小学校沖分校 が 「茶」で表示される
- なお geojeon形式ファイルは未対応であり、既定値として「赤」で表示される。

## スクリーンショット | Screenshot

### Before
- ![image](https://github.com/codeforjapan/mapprint/assets/87034/6c723493-7797-4650-bace-097e5143c5cc)

### After
- ![image](https://github.com/codeforjapan/mapprint/assets/87034/677c2795-e813-44cb-aaff-77dfcf1194d2)
