### PR TITLE
add a link of source map

### DIFF
--- a/assets/config/2024-noto-earthquake.json
+++ b/assets/config/2024-noto-earthquake.json
@@ -8,6 +8,7 @@
     {
       "id": "noto",
       "url": "https://www.google.com/maps/d/kml?forcekml=1&mid=1w0z1l210ymUPeQTgPnfZxqgh_jf5Pws",
+      "link": "https://www.google.com/maps/d/u/0/viewer?mid=1w0z1l210ymUPeQTgPnfZxqgh_jf5Pws",
       "type": "kml",
       "title": "避難所",
       "show": true
@@ -15,6 +16,7 @@
     {
       "id": "noto_kyusui",
       "url": "https://www.google.com/maps/d/kml?forcekml=1&mid=1YXwD9l2SbmCQO4SYDmTee4nrAQFiJfE",
+      "link": "https://www.google.com/maps/d/u/0/viewer?mid=1YXwD9l2SbmCQO4SYDmTee4nrAQFiJfE",
       "type": "kml",
       "title": "給水所",
       "show": true
@@ -22,6 +24,7 @@
     {
       "id": "niigata_kyusui",
       "url": "https://www.google.com/maps/d/kml?forcekml=1&mid=1s5C7_A9ZKbBcvmdg-MZSBnHhjGJDGXA",
+      "link": "https://www.google.com/maps/d/u/0/viewer?mid=1s5C7_A9ZKbBcvmdg-MZSBnHhjGJDGXA",
       "type": "kml",
       "title": "給水所",
       "show": true
@@ -29,6 +32,7 @@
     {
       "id": "gas_station_noto",
       "url": "https://www.google.com/maps/d/kml?forcekml=1&mid=1JBE8Bncl9LpfLlybDzoQ-T-eTicZcQo",
+      "link": "https://www.google.com/maps/d/u/0/viewer?mid=1JBE8Bncl9LpfLlybDzoQ-T-eTicZcQo",
       "type": "kml",
       "title": "ガソリンスタンド",
       "show": true


### PR DESCRIPTION
## 概要 | About

- Ref: #448 
- 能登半島地震の情報源 Google Mapへのリンクを追加した。
- これにより、「地域選択」に「元の地図へ」リンクが表示される (元々実装されていた機能による)。

## 動作確認方法 | How to check

- スクリーンショットの赤丸にある上矢印をクリックする
- 地域選択に登場する「元の地図へ」をクリックするとGoogle Mapを開く。

## スクリーンショット | Screenshot
![image](https://github.com/codeforjapan/mapprint/assets/87034/29006197-5a02-40f1-baad-9f2bdce7e4ed)
