### PR TITLE
`getPrintDate` を削除

### DIFF
--- a/lib/displayHelper.ts
+++ b/lib/displayHelper.ts
@@ -37,7 +37,3 @@ export function getNowYMD(dt:Date, locale?:string):string{
       return dt.toLocaleString('ja-JP');
   }
 }
-
-export function getPrintDate(dt:Date):string{
-  return `このマップは ${this.getNowYMD(dt)} に印刷しました。`;
-}


### PR DESCRIPTION
## 概要 | About

- Fix: #463

使用されていない関数 `getPrintDate` を削除します。

## 動作確認方法 | How to check

なし

## スクリーンショット | Screenshot

なし
