### PR TITLE
issue#473 add link to the top page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,7 +3,8 @@
   #fb-root
   header
     h1.index-title
-      img(src="~/assets/images/logo.png" width="895" height="160" :alt='$t("common.title")')
+      nuxt-link(to='/')
+        img(src="~/assets/images/logo.png" width="895" height="160" :alt='$t("common.title")')
   main.index-main
     ul.index-list.grid-center-equalHeight
       li.col-12_xs-6_lg-4(v-for='(map, index) in maps')

--- a/pages/map/_map.vue
+++ b/pages/map/_map.vue
@@ -6,9 +6,11 @@ div.layout-map
         .aside-grid
           .aside-item1
             h2.aside-title-sp
-              img(src="~/assets/images/sp_logo.png" width="607" height="452" :alt='$t("common.title")')
+              nuxt-link(to='/')
+                img(src="~/assets/images/sp_logo.png" width="607" height="452" :alt='$t("common.title")')
             h2.aside-title-pc
-              img(src="~/assets/images/logo.png" width="895" height="160" :alt='$t("common.title")')
+              nuxt-link(to='/')
+                img(src="~/assets/images/logo.png" width="895" height="160" :alt='$t("common.title")')
           .aside-item2
             p
               | {{$t('map.desc_1')}}
@@ -41,7 +43,8 @@ div.layout-map
               i.far.fa-arrow-alt-circle-left.fa-2x
           .banner
             .logo.print-exclude
-              img(src="~/assets/images/logo.png" width="895" height="160" :alt='$t("common.title")')
+              nuxt-link(to='/')
+                img(src="~/assets/images/logo.png" width="895" height="160" :alt='$t("common.title")')
             .sub-outer.print-exclude
               .sub-button(@click='isOpenExplain=!isOpenExplain')
                 i.fas.fa-info-circle.fa-lg


### PR DESCRIPTION
## 概要 | About

Fix: #473 
ついでに、PC表示時のロゴおよびトップページ表示時のロゴをタップした時にも、トップページに戻る処理を入れました。一般的な挙動かと思いますが、不適当でしたらご指摘ください。
その他、初めてのPRのためご確認よろしくお願いします。

## 動作確認方法 | How to check

#473 に関しては、スマートフォンで地図ページを表示してロゴをタップする。
追加処理に関しては、それぞれ地図ページ、トップページにてロゴをタップ。

ちなみに、.aside-title-sp / sp_logo.pngがPC用、.aside-title-pc / logo.pngがスマホ用なんですね。歴史的な事情でしょうか。今後のために変えても良いかと思いました。