### PR TITLE
fix(ci): PR の CI が master を検証していた問題を修正し、token 権限を最小化する

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,14 +4,17 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'

--- a/.github/workflows/generate-pages.yml
+++ b/.github/workflows/generate-pages.yml
@@ -1,14 +1,17 @@
 name: generate pages
 
 on:
-  pull_request_target:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   generate-pages:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
 
     - name: setup node
       uses: actions/setup-node@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,11 +5,14 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - name: setup node
       uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,14 +3,17 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   eslint:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,17 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'


### PR DESCRIPTION
## 問題1: PR の CI が PR の内容を検証していない

test / lint / e2e / generate-pages の4本が `pull_request_target` トリガのため、PR に表示される緑のチェックは **PR の内容ではなく master を検証した結果** でした。

`pull_request_target` では `actions/checkout` の既定の対象が base ブランチになります。実際のログで確認しました。PR #553（head = `25803b48`）の test ジョブ:

```
git fetch ... origin +1ef6dfe6...:refs/remotes/origin/master
git checkout --progress --force -B master refs/remotes/origin/master
git log -1 --format=%H
1ef6dfe6fcf5a6a2399c45bf6f81fe1046f31adb    ← master の HEAD
```

GitHub の UI 上は `head_branch` と `head_sha` が PR のものとして表示されるため、見た目では区別できません。

副作用として、放置された PR は古い判定を持ち続けます。#544 は 2026-02-17 時点の master を検証した `failure` を5か月間表示していました。同じ master に対して 2/13 と 3/4 の run は成功しているので、PR の内容とは無関係な一時的な失敗でした。

## 問題2: token 権限が既定値のまま

どのワークフローにも `permissions:` の指定がなく、リポジトリ既定値の token 権限で走っていました。問題1と組み合わさると影響が大きくなります。

## 修正

### トリガ

4本を `pull_request` に変更します。

`pull_request_target` に `ref: ${{ github.event.pull_request.head.sha }}` を足すのは **避けるべきです**。base リポジトリの文脈で書き込み可能な token 付きに fork の任意のコードを持ち込むことになります。GitHub 自身もこれを問題として扱っており、actions/checkout v7.0.0（2026-06-18）で `pull_request_target` / `workflow_run` からの fork PR チェックアウトを既定でブロックし、2026-07-20 に v4.4.0 / v5.1.0 / v6.1.0 へ BREAKING change として backport しています。

参考: https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/

この4本は secrets を参照していないので `pull_request` で足ります。

### permissions

- test / lint / e2e / generate-pages: `contents: read`
- gh-pages: `contents: write`（`peaceiris/actions-gh-pages` が gh-pages ブランチへ push するため。同 action の README が要求する権限）

`actions/upload-artifact` は `ACTIONS_RUNTIME_TOKEN` を使うので `contents: read` で足ります。

### actions/checkout

v2 / v3 / v4 が混在していたので v7 に統一します。v7 は node24 ランタイムで、Actions Runner v2.327.1 以上を要求します（GitHub ホストランナーは満たしています）。v2 は Node 16 で、すでにサポート対象外です。

## 影響

- **これまで緑だったものが赤くなる可能性があります。それが目的です。**
- dependabot の PR は read-only token で走りますが、この4本は secrets 不要なので影響なし
- fork からの PR は初回コントリビューターの承認が必要になります（正しい挙動）
- gh-pages のデプロイ挙動は変わりません（トリガ・処理は無変更、権限を明示しただけ）

## この PR 自体の検証について

この PR の CI は変更前の設定（= master を検証）で走るため、**この PR 自体の CI 結果は変更の正しさを示しません。**

マージ後、最初の PR のログで `git checkout` の対象が PR の head sha になること、および gh-pages のデプロイが成功することを確認してください。

## この PR に含めていないもの

- `gh-pages.yml` の `node-version: '20.10.0'` 直書き（他4本は `.node-version` 参照）。Node 20 はすでに EOL なので、別途対応が必要です
- `actions/setup-node@v4` / `actions/cache@v4` / `actions/upload-artifact@v4` の更新
