### PR TITLE
feat(map): 地図ページにシェアボタンを追加する

### DIFF
--- a/assets/sass/_sub.scss
+++ b/assets/sass/_sub.scss
@@ -39,3 +39,14 @@
     border: none;
   }
 }
+
+.share-button {
+  display: flex;
+  align-items: center;
+  .share-link {
+    margin-left: 0.4em;
+    i {
+      padding-right: 0;
+    }
+  }
+}

--- a/assets/sass/_sub.scss
+++ b/assets/sass/_sub.scss
@@ -4,6 +4,9 @@
 .sub-outer {
   display: flex;
   flex-direction: row;
+  // 小さい画面ではボタンが並びきらないので折り返す。
+  // md 以上は grid になるのでこの指定は効かない。
+  flex-wrap: wrap;
   align-items: center;
   @include mixin.bp(md) {
     display: grid;

--- a/assets/sass/_sub.scss
+++ b/assets/sass/_sub.scss
@@ -4,6 +4,7 @@
 .sub-outer {
   display: flex;
   flex-direction: row;
+
   // 小さい画面ではボタンが並びきらないので折り返す。
   // md 以上は grid になるのでこの指定は効かない。
   flex-wrap: wrap;

--- a/lib/shareHelper.ts
+++ b/lib/shareHelper.ts
@@ -1,3 +1,18 @@
+export const SITE_ORIGIN = 'https://kamimap.com';
+
+/**
+ * 共有する URL を決める。
+ *
+ * 通常は表示範囲がハッシュに載った location.href をそのまま使う。
+ * 静的生成の時点ではそれが取れないので、表示中のルートから組み立てる。
+ * nuxt-i18n の strategy が prefix_except_default なので、ここでルートを
+ * 使わずに地図 ID から組み立てると、日本語以外のページが日本語版の URL を
+ * 共有してしまう。
+ */
+export function buildShareUrl(fullUrl: string | null, routePath: string): string {
+  return fullUrl || SITE_ORIGIN + routePath;
+}
+
 export interface ShareLink {
   id: string;
   label: string;

--- a/lib/shareHelper.ts
+++ b/lib/shareHelper.ts
@@ -1,0 +1,41 @@
+export interface ShareLink {
+  id: string;
+  label: string;
+  iconClass: string;
+  href: string;
+}
+
+/**
+ * 地図ページを SNS で共有するためのリンクを組み立てる。
+ *
+ * トップページは公式の埋め込みウィジェット（Facebook SDK / Twitter widgets.js /
+ * LINE の social-plugin loader）を使っているが、地図ページでは使えない。
+ * 地図ページの URL は表示範囲がハッシュに載って利用者の操作で変わるのに対し、
+ * ウィジェットは描画時点の data-url を固定してしまうためで、
+ * 「いま見えている範囲の地図」を共有するには URL を都度組み立てる必要がある。
+ * 外部スクリプトを読まない分、回線の細い被災地でも表示を妨げない。
+ */
+export function buildShareLinks(shareUrl: string, shareText: string): ShareLink[] {
+  const url = encodeURIComponent(shareUrl);
+  const text = encodeURIComponent(shareText);
+  return [
+    {
+      id: 'x',
+      label: 'X',
+      iconClass: 'fab fa-x-twitter',
+      href: 'https://twitter.com/intent/tweet?url=' + url + '&text=' + text,
+    },
+    {
+      id: 'facebook',
+      label: 'Facebook',
+      iconClass: 'fab fa-facebook',
+      href: 'https://www.facebook.com/sharer/sharer.php?u=' + url,
+    },
+    {
+      id: 'line',
+      label: 'LINE',
+      iconClass: 'fab fa-line',
+      href: 'https://social-plugins.line.me/lineit/share?url=' + url + '&text=' + text,
+    },
+  ];
+}

--- a/pages/map/_map.vue
+++ b/pages/map/_map.vue
@@ -92,7 +92,7 @@ import VueQrcode from '@chenfengyuan/vue-qrcode'
 import PrintableMap from '~/components/PrintableMap'
 import { getNowYMD } from '~/lib/displayHelper.ts'
 import Modal from '~/components/Modal'
-import { buildShareLinks } from '~/lib/shareHelper'
+import { buildShareLinks, buildShareUrl } from '~/lib/shareHelper'
 if (process.client) {
   require('viewport-units-buggyfill').init()
 }
@@ -117,8 +117,8 @@ export default {
   },
   computed: {
     shareUrl () {
-      // fullURL は mounted 後にしか入らないので、静的生成時は地図ページの正規 URL を使う
-      return this.fullURL || 'https://kamimap.com/map/' + this.mapConfig.map_id
+      // fullURL は mounted 後にしか入らないので、静的生成時は表示中のルートから組み立てる
+      return buildShareUrl(this.fullURL, this.$route.path)
     },
     shareText () {
       const title = this.$i18n.locale === 'ja' ? this.mapConfig.map_title : this.mapConfig.map_title_en

--- a/pages/map/_map.vue
+++ b/pages/map/_map.vue
@@ -53,6 +53,17 @@ div.layout-map
               .sub-button.github-link
                 i.fab.fa-github.fa-lg
                 a(href="https://github.com/codeforjapan/mapprint") {{ $t('common.contribute') }}
+              .sub-button.share-button
+                i.fas.fa-share-nodes.fa-lg
+                a.share-link(
+                  v-for="link in shareLinks"
+                  :key="link.id"
+                  :href="link.href"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  :aria-label="$t('common.share') + ' (' + link.label + ')'"
+                )
+                  i.fa-lg(:class="link.iconClass")
               .sub-button
                 i.fas.fa-language.fa-lg
                 select(onChange="location.href=value;")
@@ -81,6 +92,7 @@ import VueQrcode from '@chenfengyuan/vue-qrcode'
 import PrintableMap from '~/components/PrintableMap'
 import { getNowYMD } from '~/lib/displayHelper.ts'
 import Modal from '~/components/Modal'
+import { buildShareLinks } from '~/lib/shareHelper'
 if (process.client) {
   require('viewport-units-buggyfill').init()
 }
@@ -101,6 +113,19 @@ export default {
       isOpenExplain: false,
       fullURL: null,
       updated_at: null
+    }
+  },
+  computed: {
+    shareUrl () {
+      // fullURL は mounted 後にしか入らないので、静的生成時は地図ページの正規 URL を使う
+      return this.fullURL || 'https://kamimap.com/map/' + this.mapConfig.map_id
+    },
+    shareText () {
+      const title = this.$i18n.locale === 'ja' ? this.mapConfig.map_title : this.mapConfig.map_title_en
+      return title + ' - ' + this.$i18n.t('common.site_desc')
+    },
+    shareLinks () {
+      return buildShareLinks(this.shareUrl, this.shareText)
     }
   },
   head () {

--- a/test-unit/lib/shareHelper.spec.js
+++ b/test-unit/lib/shareHelper.spec.js
@@ -1,4 +1,4 @@
-import { buildShareLinks } from '~/lib/shareHelper';
+import { buildShareLinks, buildShareUrl } from '~/lib/shareHelper';
 
 describe('buildShareLinks', () => {
   const url = 'https://kamimap.com/map/2024-noto-earthquake#37.4,136.8-37.2,137.3';
@@ -31,6 +31,11 @@ describe('buildShareLinks', () => {
     links.forEach((link) => {
       expect(link.href).toContain('https%3A%2F%2Fexample.com%2F%3Fa%3D1%26b%3D2');
     });
+    links
+      .filter((link) => link.id !== 'facebook')
+      .forEach((link) => {
+        expect(link.href).toContain(encodeURIComponent('A & B'));
+      });
   });
 
   test('every link is an absolute https url', () => {
@@ -38,5 +43,26 @@ describe('buildShareLinks', () => {
     links.forEach((link) => {
       expect(link.href.startsWith('https://')).toBe(true);
     });
+  });
+});
+
+describe('buildShareUrl', () => {
+  test('uses the live url once it is available', () => {
+    const live = 'https://kamimap.com/en/map/2024-noto-earthquake#37.4,136.8-37.2,137.3';
+    expect(buildShareUrl(live, '/en/map/2024-noto-earthquake')).toBe(live);
+  });
+
+  test('keeps the locale prefix when falling back to the route', () => {
+    // strategy は prefix_except_default なので、日本語以外は接頭辞が付く。
+    // これを落とすと英語ページが日本語版の URL を共有してしまう
+    expect(buildShareUrl(null, '/en/map/2024-noto-earthquake')).toBe(
+      'https://kamimap.com/en/map/2024-noto-earthquake'
+    );
+  });
+
+  test('leaves the default locale unprefixed', () => {
+    expect(buildShareUrl(null, '/map/2024-noto-earthquake')).toBe(
+      'https://kamimap.com/map/2024-noto-earthquake'
+    );
   });
 });

--- a/test-unit/lib/shareHelper.spec.js
+++ b/test-unit/lib/shareHelper.spec.js
@@ -1,0 +1,42 @@
+import { buildShareLinks } from '~/lib/shareHelper';
+
+describe('buildShareLinks', () => {
+  const url = 'https://kamimap.com/map/2024-noto-earthquake#37.4,136.8-37.2,137.3';
+  const text = '令和6年能登半島地震関連情報 - 地図情報を印刷できる「紙マップ」';
+
+  test('returns one link per service, in a stable order', () => {
+    const links = buildShareLinks(url, text);
+    expect(links.map((link) => link.id)).toEqual(['x', 'facebook', 'line']);
+  });
+
+  test('carries the displayed area by encoding the whole url', () => {
+    const links = buildShareLinks(url, text);
+    links.forEach((link) => {
+      expect(link.href).toContain(encodeURIComponent(url));
+      // 生のハッシュが残るとクエリが途中で切れ、表示範囲が伝わらない
+      expect(link.href).not.toContain('#');
+    });
+  });
+
+  test('passes the share text only to the services that accept one', () => {
+    const links = buildShareLinks(url, text);
+    const withText = links.filter((link) =>
+      link.href.includes(encodeURIComponent(text))
+    );
+    expect(withText.map((link) => link.id)).toEqual(['x', 'line']);
+  });
+
+  test('encodes text that would otherwise break the query string', () => {
+    const links = buildShareLinks('https://example.com/?a=1&b=2', 'A & B');
+    links.forEach((link) => {
+      expect(link.href).toContain('https%3A%2F%2Fexample.com%2F%3Fa%3D1%26b%3D2');
+    });
+  });
+
+  test('every link is an absolute https url', () => {
+    const links = buildShareLinks(url, text);
+    links.forEach((link) => {
+      expect(link.href.startsWith('https://')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #471

地図ページ（`pages/map/_map.vue`）のヘッダーに X / Facebook / LINE のシェアリンクを追加します。

## トップページと同じウィジェットを使わなかった理由

トップページ（`pages/index.vue`）は Facebook SDK・`widgets.js`・LINE の social-plugin loader を読み込んで公式ウィジェットを描画していますが、地図ページでは同じ方法が機能しません。

地図ページの URL は表示範囲がハッシュに載り、利用者が地図を動かすたびに変わります。`updateQRCode` が QR コードに反映しているのと同じ値です。一方で公式ウィジェットは描画時点の `data-url` を固定するため、地図を動かしたあとに押しても最初の範囲が共有されてしまいます。「いま見えている範囲の地図」を渡せることがこのページの価値だと考えたので、各サービスのシェア用 URL を都度組み立てる形にしました。

副次的な利点として、地図ページに外部スクリプトが増えません。回線の細い環境で開かれうるページなので、表示を妨げない方が望ましいと考えました。

## スクリーンショット

Playwright + Chromium 144 で `.header` を撮影しています。

### モバイル（390px）

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/yasumorishima/mapprint/screenshots/share-buttons-471/share-buttons/before-mobile-390.png" width="390"> | <img src="https://raw.githubusercontent.com/yasumorishima/mapprint/screenshots/share-buttons-471/share-buttons/after-mobile-390.png" width="390"> |

### デスクトップ（1280px）

| before |
|---|
| <img src="https://raw.githubusercontent.com/yasumorishima/mapprint/screenshots/share-buttons-471/share-buttons/before-desktop.png"> |

| after |
|---|
| <img src="https://raw.githubusercontent.com/yasumorishima/mapprint/screenshots/share-buttons-471/share-buttons/after-desktop.png"> |

## 実装

- `lib/shareHelper.ts` に純関数 `buildShareUrl` / `buildShareLinks` を追加し、`test-unit/lib/shareHelper.spec.js` で検証しています
- 共有する URL は `fullURL`（`location.href`、表示範囲込み）です。静的生成の時点では取れないので、その場合は表示中のルートから組み立てます。`strategy` が `prefix_except_default` なので、ここで地図 ID から組み立てると日本語以外のページが日本語版の URL を共有してしまいます
- 共有文言はロケールに応じた地図タイトル + `common.site_desc`
- ボタンは既存の `.sub-button` を踏襲しました。親の `.sub-outer` が `print-exclude` なので、印刷時には出ません
- アイコンは同梱の Font Awesome 6.5.1 に含まれるものだけを使っています（`fa-share-nodes` / `fa-x-twitter` / `fa-facebook` / `fa-line`）
- 翻訳キーは追加していません。既存の `common.share` と `common.site_desc` を使っています。13 ロケールすべてに揃っていることを確認済みです
- 各リンクに `rel="noopener noreferrer"` と、サービス名を含む `aria-label` を付けています

## `.sub-outer` に `flex-wrap` を足した理由

`.sub-outer` の子が 1 つ増えるため、幅の足りない画面で既存ボタンが `flex-shrink` で縮みます。Chromium 144 で「このサイトについて」の実効幅を測ると次のとおりでした。

| ビューポート | master | シェアボタン追加のみ | `flex-wrap` 追加後 |
|---|---|---|---|
| 320px | 125px | 25px | 147px |
| 375px | 147px | 80px | 147px |
| 390px | 147px | 95px | 147px |
| 414px | 147px | 119px | 147px |

いずれの条件でも `documentElement.scrollWidth` はビューポート幅と一致しており、横スクロールは発生していません。折り返しを許可すると 4 幅とも自然幅に戻り、Language セレクタが 2 行目に落ちます。`md` 以上では `display: grid` に切り替わるため、この指定は効きません。

## 確認したこと

- `yarn run lint` — エラーなし（警告 26 件はいずれも既存ファイルのもので、本 PR の追加分に指摘はありません）
- `yarn test:unit` — 14 passed
- `yarn build` — 成功
