### PR TITLE
test: 地図のロジックに回帰テストを追加する

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,10 @@ module.exports = {
     '^.+\\.vue$': '@vue/vue2-jest',
   },
   moduleNameMapper: {
+    '\\.(css|scss|sass)$': '<rootDir>/test-unit/mocks/styleMock.js',
+    '\\.(svg|png|jpg|jpeg|gif|webp)$': '<rootDir>/test-unit/mocks/fileMock.js',
     '^~/(.*)$': '<rootDir>/$1',
+    '^@/(.*)$': '<rootDir>/$1',
   },
   testMatch: ['<rootDir>/test-unit/**/*.spec.js'],
   snapshotSerializers: ['<rootDir>/node_modules/jest-serializer-vue'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/jest.setup.js'],
   moduleFileExtensions: ['js', 'ts', 'json', 'vue'],
   transform: {
     '^.+\\.js$': 'babel-jest',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,10 @@
+// maplibre-gl は import 時点で window.URL.createObjectURL を参照するが、
+// jsdom には実装がないため補う。WebGL を使う描画自体はテスト対象にしない。
+if (typeof window !== 'undefined') {
+  if (!window.URL.createObjectURL) {
+    window.URL.createObjectURL = () => '';
+  }
+  if (!window.URL.revokeObjectURL) {
+    window.URL.revokeObjectURL = () => {};
+  }
+}

--- a/test-unit/components/PrintableMap.markers.spec.js
+++ b/test-unit/components/PrintableMap.markers.spec.js
@@ -1,0 +1,154 @@
+import { mount } from '@vue/test-utils';
+import PrintableMap from '~/components/PrintableMap.vue';
+
+// PrintableMap のうち、地図ライブラリに依存しない部分を固定する。
+// 表示範囲での絞り込みとカテゴリ分類は、印刷される POI 一覧の中身を決めているので、
+// ここが壊れると紙の内容が変わる。地図の生成方法とは独立しているため、
+// 地図コンポーネントはスタブに置き換えてマウントする。
+
+jest.mock('ky', () => ({ default: { get: () => ({ text: async () => '' }) } }));
+
+const MAP_STUBS = {
+  'client-only': { template: '<div><slot /></div>' },
+  simplebar: { template: '<div><slot /></div>' },
+  MglMap: { template: '<div><slot /></div>' },
+  MglMarker: { template: '<div><slot /></div>' },
+  MglPopup: { template: '<div><slot /></div>' },
+  MglGeolocateControl: { template: '<div />' },
+};
+
+const mapConfig = () => ({
+  map_id: 'test',
+  map_title: 'テスト',
+  center: [130.7, 32.6],
+  default_hash: '32.7,130.6-32.5,130.8',
+  type: 'geojson',
+  sources: [],
+  layer_settings: {
+    給水: { name: '給水所', color: '#285797', bg_color: '#A3BBDA' },
+    避難所: { name: '避難所', color: '#276445', bg_color: '#A4C1B0' },
+  },
+});
+
+const translate = (key) => (key === 'category.給水所' ? '給水ポイント' : key);
+
+const marker = (lng, lat, name, category = '給水') => ({
+  category,
+  feature: {
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [lng, lat] },
+    properties: { name, 'name:en': name + ' (en)' },
+  },
+});
+
+// 熊本県宇城市付近を囲む矩形（inBounds は差の積の符号で判定する）
+const bounds = {
+  getNorthEast: () => ({ lng: 130.8, lat: 32.7 }),
+  getSouthWest: () => ({ lng: 130.6, lat: 32.5 }),
+  getNorthWest: () => ({ lng: 130.6, lat: 32.7 }),
+  getSouthEast: () => ({ lng: 130.8, lat: 32.5 }),
+};
+
+const LAYERS = [
+  {
+    source: { id: 'a', title: '水', type: 'geojson', show: true, url: 'http://example.test/a' },
+    markers: [
+      marker(130.7, 32.6, '氷川町役場'),
+      marker(130.68, 32.55, '宮原振興局'),
+      marker(131.9, 33.9, '範囲外の地点'),
+    ],
+  },
+  {
+    source: { id: 'b', title: '避難', type: 'geojson', show: true, url: 'http://example.test/b' },
+    markers: [marker(130.72, 32.58, '竜北中学校', '避難所')],
+  },
+];
+
+const factory = async (data = {}) => {
+  const wrapper = mount(PrintableMap, {
+    propsData: { mapConfig: mapConfig() },
+    stubs: MAP_STUBS,
+    mocks: { $i18n: { locale: 'ja', t: (key) => key }, $t: (key) => key },
+  });
+  await wrapper.setData({ layers: LAYERS, checkedArea: ['水', '避難'], ...data });
+  await wrapper.vm.$nextTick();
+  return wrapper;
+};
+
+describe('PrintableMap の表示対象の絞り込み', () => {
+  test('bounds が無いときは全てのマーカーを対象にする', async () => {
+    const wrapper = await factory();
+    expect(wrapper.vm.inBoundsMarkers).toHaveLength(4);
+  });
+
+  test('bounds の外にあるマーカーを除外する', async () => {
+    const wrapper = await factory({ bounds });
+    const names = wrapper.vm.inBoundsMarkers.map((m) => m.feature.properties.name);
+    expect(names).toEqual(['氷川町役場', '宮原振興局', '竜北中学校']);
+  });
+
+  test('チェックの外れたエリアのマーカーを除外する', async () => {
+    const wrapper = await factory({ bounds, checkedArea: ['水'] });
+    const names = wrapper.vm.inBoundsMarkers.map((m) => m.feature.properties.name);
+    expect(names).toEqual(['氷川町役場', '宮原振興局']);
+  });
+
+  test('source.show が false のレイヤーを除外する', async () => {
+    const layers = [{ ...LAYERS[0], source: { ...LAYERS[0].source, show: false } }, LAYERS[1]];
+    const wrapper = await factory({ bounds, layers });
+    const names = wrapper.vm.inBoundsMarkers.map((m) => m.feature.properties.name);
+    expect(names).toEqual(['竜北中学校']);
+  });
+});
+
+describe('PrintableMap のカテゴリ分類', () => {
+  test('表示対象をカテゴリごとにまとめる', async () => {
+    const wrapper = await factory({ bounds });
+    const groups = wrapper.vm.displayMarkersGroupByCategory;
+    expect(groups.map((g) => g.category)).toEqual(['給水', '避難所']);
+    expect(groups[0].markers).toHaveLength(2);
+    expect(groups[1].markers).toHaveLength(1);
+  });
+
+  // getMarkerCategoryText は category.<名前> の翻訳があればそれを使い、
+  // 無ければカテゴリ名をそのまま返す。両方の分岐を確認する。
+  test('翻訳があれば翻訳を、無ければカテゴリ名をそのまま返す', async () => {
+    const wrapper = mount(PrintableMap, {
+      propsData: { mapConfig: mapConfig() },
+      stubs: MAP_STUBS,
+      mocks: {
+        // 実装が $i18n.t / $t のどちらを使っても同じ結果になるよう両方に入れる。
+        // category.給水所 だけ翻訳がある状態を作る。
+        $i18n: { locale: 'ja', t: translate },
+        $t: translate,
+      },
+    });
+    expect(wrapper.vm.getMarkerCategoryText('給水所', 'ja')).toBe('給水ポイント');
+    expect(wrapper.vm.getMarkerCategoryText('翻訳のないカテゴリ', 'ja')).toBe('翻訳のないカテゴリ');
+    // undefined は '未分類' として扱われる
+    expect(wrapper.vm.getMarkerCategoryText(undefined, 'ja')).toBe('未分類');
+  });
+
+  test('ロケール別の名前があればそれを優先する', async () => {
+    const wrapper = await factory();
+    const props = { name: '氷川町役場', 'name:en': 'Hikawa Town Hall' };
+    expect(wrapper.vm.getMarkerNameText(props, 'ja')).toBe('氷川町役場');
+    expect(wrapper.vm.getMarkerNameText(props, 'en')).toBe('Hikawa Town Hall');
+    expect(wrapper.vm.getMarkerNameText({ name: '名前だけ' }, 'en')).toBe('名前だけ');
+  });
+});
+
+describe('PrintableMap の印刷される一覧', () => {
+  test('カテゴリごとの節と件数が描画される', async () => {
+    const wrapper = await factory({ bounds });
+    const sections = wrapper.findAll('.list-section');
+    expect(sections).toHaveLength(2);
+    expect(wrapper.findAll('.list-items li')).toHaveLength(3);
+  });
+
+  test('表示対象が無いときは「該当なし」を出す', async () => {
+    const wrapper = await factory({ bounds, checkedArea: [] });
+    expect(wrapper.vm.inBoundsMarkers).toHaveLength(0);
+    expect(wrapper.find('.list-section-none').exists()).toBe(true);
+  });
+});

--- a/test-unit/lib/MapHelper.bounds.spec.js
+++ b/test-unit/lib/MapHelper.bounds.spec.js
@@ -1,0 +1,77 @@
+import MapLibre from 'maplibre-gl';
+import MapHelper from '~/lib/MapHelper';
+
+// vue-mapbox を撤去して maplibre-gl を直接使う変更のための回帰テスト。
+// PrintableMap は地図の移動ごとに bounds を取り直し、URL ハッシュと
+// マーカーの絞り込みに使う。この3つの挙動は実装を入れ替えても変わってはいけない。
+
+const helper = new MapHelper();
+
+// 熊本県宇城市付近（震度7の観測点）を囲む矩形
+const NW = { lat: 32.7, lng: 130.6 };
+const SE = { lat: 32.5, lng: 130.8 };
+const bounds = new MapLibre.LngLatBounds(
+  new MapLibre.LngLat(NW.lng, SE.lat), // south west
+  new MapLibre.LngLat(SE.lng, NW.lat)  // north east
+);
+
+describe('MapHelper bounds のシリアライズ', () => {
+  test('serializeBounds は "北西lat,lng-南東lat,lng" を返す', () => {
+    expect(helper.serializeBounds(bounds)).toBe('32.7,130.6-32.5,130.8');
+  });
+
+  // 注意: serializeBounds は「北西 → 南東」の順で書き出すが、deserializeBounds は
+  // new LngLatBounds([a, b]) に渡すため maplibre 側が「[南西, 北東]」として解釈する。
+  // その結果、経度は正しく復元されるが緯度は _sw / _ne が入れ替わる。
+  // 復元後の bounds の用途は fitBounds（2隅を囲むだけ）と inBounds（差の積の符号で
+  // 判定）に限られ、どちらも角の順序に依存しないため実害が出ていない。
+  // 実装を入れ替えるときはこの非対称性を「直さない」こと。直すと URL ハッシュの
+  // 互換性が変わる。
+  const extentOf = (b) => {
+    const lats = [b.getNorthEast().lat, b.getSouthWest().lat];
+    const lngs = [b.getNorthEast().lng, b.getSouthWest().lng];
+    return {
+      latMin: Math.min(...lats), latMax: Math.max(...lats),
+      lngMin: Math.min(...lngs), lngMax: Math.max(...lngs),
+    };
+  };
+
+  test('deserializeBounds は serializeBounds の出力と同じ範囲を復元する', () => {
+    const e = extentOf(helper.deserializeBounds(helper.serializeBounds(bounds)));
+    expect(e.latMin).toBeCloseTo(SE.lat, 6);
+    expect(e.latMax).toBeCloseTo(NW.lat, 6);
+    expect(e.lngMin).toBeCloseTo(NW.lng, 6);
+    expect(e.lngMax).toBeCloseTo(SE.lng, 6);
+  });
+
+  test('deserializeBounds は設定ファイルの default_hash を解釈できる', () => {
+    // assets/config/2024-noto-earthquake.json の default_hash と同じ形式
+    const hash = '37.47529547606749,136.86173646804122-37.23376666876564,137.36853736803096';
+    const e = extentOf(helper.deserializeBounds(hash));
+    expect(e.latMin).toBeCloseTo(37.23376666876564, 6);
+    expect(e.latMax).toBeCloseTo(37.47529547606749, 6);
+    expect(e.lngMin).toBeCloseTo(136.86173646804122, 6);
+    expect(e.lngMax).toBeCloseTo(137.36853736803096, 6);
+  });
+
+  test('deserializeBounds は不正な文字列に対して undefined を返す', () => {
+    expect(helper.deserializeBounds('')).toBeUndefined();
+    expect(helper.deserializeBounds('not-a-bounds')).toBeUndefined();
+  });
+});
+
+describe('MapHelper.inBounds によるマーカーの絞り込み', () => {
+  test.each([
+    ['矩形の内側', [130.7, 32.6], true],
+    ['経度が西に外れる', [130.5, 32.6], false],
+    ['経度が東に外れる', [130.9, 32.6], false],
+    ['緯度が北に外れる', [130.7, 32.8], false],
+    ['緯度が南に外れる', [130.7, 32.4], false],
+  ])('%s → %p', (_label, point, expected) => {
+    expect(helper.inBounds(point, bounds)).toBe(expected);
+  });
+
+  test('境界線上の点は内側と判定されない（現在の実装の挙動）', () => {
+    expect(helper.inBounds([NW.lng, NW.lat], bounds)).toBe(false);
+  });
+});

--- a/test-unit/lib/MapHelper.kml.spec.js
+++ b/test-unit/lib/MapHelper.kml.spec.js
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import MapHelper from '~/lib/MapHelper';
+
+// KML の取り込みは mapprint の中核。webpack から Vite に変わって
+// @mapbox/togeojson の import 形が変わると、例外を出さずにマーカー0件になる。
+// 静かに壊れる経路なので固定する。
+const kml = fs.readFileSync(
+  path.join(process.cwd(), 'static/data/kml/2024-noto.kml'),
+  'utf-8'
+);
+
+describe('MapHelper.parse で KML を読む', () => {
+  const helper = new MapHelper();
+
+  test('KML から1件以上のマーカーを取り出せる', () => {
+    const [markers] = helper.parse('kml', kml, undefined);
+    expect(Array.isArray(markers)).toBe(true);
+    expect(markers.length).toBeGreaterThan(0);
+  });
+
+  test('各マーカーが座標とカテゴリを持つ', () => {
+    const [markers] = helper.parse('kml', kml, undefined);
+    markers.slice(0, 20).forEach((m) => {
+      expect(m.category).toBeTruthy();
+      expect(m.feature.geometry.type).toBe('Point');
+      const [lng, lat] = m.feature.geometry.coordinates;
+      expect(typeof lng).toBe('number');
+      expect(typeof lat).toBe('number');
+      // 能登半島のあたりに収まっていること
+      expect(lng).toBeGreaterThan(135);
+      expect(lng).toBeLessThan(140);
+      expect(lat).toBeGreaterThan(35);
+      expect(lat).toBeLessThan(40);
+    });
+  });
+});

--- a/test-unit/mocks/fileMock.js
+++ b/test-unit/mocks/fileMock.js
@@ -1,0 +1,2 @@
+// SVG や画像の require はテストではパス文字列として扱う
+module.exports = 'test-file-stub';

--- a/test-unit/mocks/styleMock.js
+++ b/test-unit/mocks/styleMock.js
@@ -1,0 +1,2 @@
+// CSS の import はテストでは解釈しない
+module.exports = {};


### PR DESCRIPTION
## 概要 | About

`lib/MapHelper.ts` と `components/PrintableMap.vue` に回帰テストを追加します。
本体コードの変更はありません。テストは 6件 → 35件になります。

紙マップの中核は「取り込んだ地点を表示範囲で絞り込み、カテゴリごとに並べて印刷する」流れですが、ここが壊れても例外が出ないため印刷するまで気づけません。
この後 vue-mapbox の撤去と Nuxt 4 移行を予定しているので、先に安全網を用意したいです。

追加したもの

- `MapHelper.bounds.spec.js`（10件）URLハッシュとマーカー絞り込みに使う `serializeBounds` / `deserializeBounds` / `inBounds`
- `MapHelper.kml.spec.js`（2件）`static/data/kml/2024-noto.kml` を実際に読んで座標とカテゴリを検証。ネットワークは使いません
- `PrintableMap.markers.spec.js`（9件）印刷されるPOI一覧の中身。表示範囲での絞り込み、エリアのチェック、カテゴリ分類、ロケール別の名前

`jest.setup.js` は `maplibre-gl` が import 時に参照する `window.URL.createObjectURL` を jsdom に補うためのものです。
`jest.config.js` には CSS・SVG・`@/` の `moduleNameMapper` を追加しました。`PrintableMap` が CSS と SVG を import しているため、これがないとマウントできません。

`serializeBounds` と `deserializeBounds` が非対称（経度は復元されるが緯度が `_sw` / `_ne` で入れ替わる）なことに気づきましたが、用途が `fitBounds` と `inBounds` に限られ両方とも角の順序に依存しないため実害はありません。
直すとURLハッシュの解釈が変わって既に配布された印刷物の表示範囲がずれるので、直さずテスト側で範囲として比較しています。

Nuxt 4 では jest が使えなくなるため、これらのテストは移行PRで vitest 向けに書き換わります。

## 動作確認方法 | How to check

```
yarn install
yarn test:unit   # 6 suites / 35 tests passed
yarn run lint    # 0 errors
```

本体コードを変更していないので `yarn run generate` の出力も変わりません。

## スクリーンショット | Screenshot

なし（見た目に影響しません）
