### PR TITLE
fix: vue-mapbox を撤去して maplibre-gl を直接使う (for migration to nuxt-4)

### DIFF
--- a/components/PrintableMap.vue
+++ b/components/PrintableMap.vue
@@ -3,46 +3,38 @@ div
   client-only
     div(v-if='layers.length')
       .map-outer
-        MglMap(:mapStyle.sync="mapStyle"
-          :center='center', :zoom='15', @load="load"
-          preserveDrawingBuffer=true
-          sourceId="basemap", ref="map_obj"
-        )#map
-          MglGeolocateControl
-          MglMarker(
-            v-for="(marker, index) in inBoundsMarkers"
-            :key="String(index)"
-            :coordinates="marker.feature.geometry.coordinates"
-            anchor="top-left"
-          )
-            template(slot="marker")
-              div.marker
-                span(
-                  :style="{background:mapConfig.layer_settings[marker.category]?.color||marker.feature.properties['marker-color']||'red'}"
-                  :class="{show: isDisplayAllCategory || activeCategory === marker.category}"
+        #map(ref="map_container")
+        //- maplibre の Marker / Popup に渡す DOM は Vue 側で描画しておく。
+        //- 元の要素をそのまま渡すと Vue の管理下から DOM が移動して patch が壊れるため、
+        //- 地図へ渡すのは複製（cloneNode）にする。装飾のロジックはここに残す。
+        .marker-sources(v-show="false")
+          div(v-for="(marker, index) in inBoundsMarkers" :key="markerKey(marker)")
+            div.marker(ref="markerEls")
+              span(
+                :style="{background:mapConfig.layer_settings[marker.category]?.color||marker.feature.properties['marker-color']||'red'}"
+                :class="{show: isDisplayAllCategory || activeCategory === marker.category}"
+              )
+                i(
+                  :class="[mapConfig.layer_settings[marker.category]?.icon_class, mapConfig.layer_settings[marker.category]?.class]"
+                  :style="{backgroundColor:mapConfig.layer_settings[marker.category]?.color, display:mapConfig.layer_settings[marker.category]?'inline':'none'}"
                 )
-                  i(
-                    :class="[mapConfig.layer_settings[marker.category]?.icon_class, mapConfig.layer_settings[marker.category]?.class]"
-                    :style="{backgroundColor:mapConfig.layer_settings[marker.category]?.color, display:mapConfig.layer_settings[marker.category]?'inline':'none'}"
-                  )
-                  b.number(
-                    :style="{background:mapConfig.layer_settings[marker.category]?.bg_color}"
-                  ) {{index + 1}}
-            MglPopup
-              div
-                div.popup-type
-                  i(
-                    :class="[mapConfig.layer_settings[marker.category]?.icon_class, mapConfig.layer_settings[marker.category]?.class]"
-                    :style="{backgroundColor:mapConfig.layer_settings[marker.category]?.color}"
-                  )
-                  span.popup-poi-type
-                    | {{getMarkerCategoryText(mapConfig.layer_settings[marker.category]?.name||marker.category, $i18n.locale)}}
-                p
-                  | {{$i18n.t("PrintableMap.name")}} {{getMarkerNameText(marker.feature.properties, $i18n.locale)}}
-                div.popup-detail-content
-                  p(
-                    v-html="marker.feature.properties.description ? marker.feature.properties.description : ''"
-                  )
+                b.number(
+                  :style="{background:mapConfig.layer_settings[marker.category]?.bg_color}"
+                ) {{index + 1}}
+            div(ref="popupEls")
+              div.popup-type
+                i(
+                  :class="[mapConfig.layer_settings[marker.category]?.icon_class, mapConfig.layer_settings[marker.category]?.class]"
+                  :style="{backgroundColor:mapConfig.layer_settings[marker.category]?.color}"
+                )
+                span.popup-poi-type
+                  | {{getMarkerCategoryText(mapConfig.layer_settings[marker.category]?.name||marker.category, $i18n.locale)}}
+              p
+                | {{$i18n.t("PrintableMap.name")}} {{getMarkerNameText(marker.feature.properties, $i18n.locale)}}
+              div.popup-detail-content
+                p(
+                  v-html="marker.feature.properties.description ? marker.feature.properties.description : ''"
+                )
       .legend-navi
         .area-select(:class='{open: isOpenAreaSelect}')
           .area-close(@click="isOpenAreaSelect=false")
@@ -159,8 +151,9 @@ export default {
       locale = "ja";
     }
     return {
+      // maplibre の Map と Marker は data に置かない。Vue 2 が深くリアクティブ化して
+      // WebGL 由来のオブジェクトを走査してしまうため、created で非リアクティブに持つ。
       layers: [],
-      map: null,
       bounds: null,
       updated_at: null,
       previous_hash: "",
@@ -227,6 +220,39 @@ export default {
       },
     },
   },
+  created() {
+    // 非リアクティブに保持する。key は markerKey()、値は MapLibre.Marker。
+    this.map = null;
+    this.markerCache = {};
+  },
+  watch: {
+    layers() {
+      if (this.layers.length && !this.map) {
+        this.$nextTick(this.initMap);
+      }
+    },
+    inBoundsMarkers() {
+      this.$nextTick(this.syncMarkers);
+    },
+    // 凡例のカテゴリ選択はマーカーの見た目（show クラス）を変える。
+    // 複製を地図に渡しているので作り直す。クリック起点なのでちらつきは問題にならない。
+    activeCategory() {
+      this.$nextTick(this.rebuildMarkers);
+    },
+    isDisplayAllCategory() {
+      this.$nextTick(this.rebuildMarkers);
+    },
+  },
+  beforeDestroy() {
+    Object.keys(this.markerCache).forEach((key) => {
+      this.markerCache[key].remove();
+      delete this.markerCache[key];
+    });
+    if (this.map) {
+      this.map.remove();
+      this.map = null;
+    }
+  },
   mounted() {
     const MapHelper = require("~/lib/MapHelper.ts").default;
     const ky = require("ky").default;
@@ -282,26 +308,95 @@ export default {
     });
   },
   methods: {
+    // 地図コンテナは template の v-if='layers.length' の内側にあるため、
+    // mounted の時点では存在しない。layers が埋まってから呼ばれる。
+    initMap() {
+      const container = this.$refs.map_container;
+      if (!container || this.map) {
+        return;
+      }
+      this.map = new MapLibre.Map({
+        container,
+        style: this.mapStyle,
+        center: this.center,
+        zoom: 15,
+        // 印刷時に canvas を読み戻すため必須。落とすと画面では正常に見えるのに
+        // 印刷結果の地図が白くなる。
+        preserveDrawingBuffer: true,
+      });
+      this.map.addControl(new MapLibre.NavigationControl());
+      this.map.addControl(new MapLibre.GeolocateControl({ trackUserLocation: false }));
+      this.load();
+      this.$nextTick(this.syncMarkers);
+    },
     load() {
       const locationhash = window.location.hash.substr(1);
       let initbounds = helper.deserializeBounds(locationhash);
-      this.map = this.$refs.map_obj;
       if (initbounds !== undefined) {
-        this.map.map.fitBounds(initbounds, { linear: false });
+        this.map.fitBounds(initbounds, { linear: false });
       } else {
         initbounds = helper.deserializeBounds(this.mapConfig.default_hash);
         if (initbounds !== undefined) {
-          this.map.map.fitBounds(initbounds, { linear: false });
+          this.map.fitBounds(initbounds, { linear: false });
         }
       }
-      this.map.map.on("moveend", this.etmitBounds);
+      this.map.on("moveend", this.etmitBounds);
       this.etmitBounds();
-      this.map.map.addControl(new MapLibre.NavigationControl());
     },
     etmitBounds() {
-      this.bounds = this.map.map.getBounds();
+      this.bounds = this.map.getBounds();
       this.setHash(this.bounds);
       this.$emit("bounds-changed");
+    },
+    // 座標・カテゴリ・名称で一意にする。地図移動のたびに全消しせず差分更新するための鍵。
+    markerKey(marker) {
+      const coordinates = marker.feature.geometry.coordinates.join(",");
+      const name = marker.feature.properties.name || "";
+      return marker.category + "|" + coordinates + "|" + name;
+    },
+    syncMarkers() {
+      if (!this.map) {
+        return;
+      }
+      const markerEls = this.$refs.markerEls || [];
+      const popupEls = this.$refs.popupEls || [];
+      const wanted = {};
+      this.inBoundsMarkers.forEach((marker, index) => {
+        const key = this.markerKey(marker);
+        wanted[key] = true;
+        if (this.markerCache[key]) {
+          return;
+        }
+        const markerEl = markerEls[index];
+        if (!markerEl) {
+          return;
+        }
+        const popup = new MapLibre.Popup({ offset: 12 });
+        const popupEl = popupEls[index];
+        if (popupEl) {
+          popup.setDOMContent(popupEl.cloneNode(true));
+        }
+        this.markerCache[key] = new MapLibre.Marker({
+          element: markerEl.cloneNode(true),
+          anchor: "top-left",
+        })
+          .setLngLat(marker.feature.geometry.coordinates)
+          .setPopup(popup)
+          .addTo(this.map);
+      });
+      Object.keys(this.markerCache).forEach((key) => {
+        if (!wanted[key]) {
+          this.markerCache[key].remove();
+          delete this.markerCache[key];
+        }
+      });
+    },
+    rebuildMarkers() {
+      Object.keys(this.markerCache).forEach((key) => {
+        this.markerCache[key].remove();
+        delete this.markerCache[key];
+      });
+      this.syncMarkers();
     },
     setHash(bounds) {
       const s = helper.serializeBounds(bounds);

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -67,7 +67,6 @@ export default {
    ** Plugins to load before mounting the App
    */
   plugins: [
-    { src: "~/plugins/mapbox", mode: "client" },
     { src: "~/plugins/simplebar", mode: "client" },
   ],
   /*

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "ts-node": "^8.10.2",
     "viewport-units-buggyfill": "^0.6.2",
     "vue": "^2.7.16",
-    "vue-i18n": "^8.28.2",
-    "vue-mapbox": "^0.4.1"
+    "vue-i18n": "^8.28.2"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",

--- a/plugins/mapbox.js
+++ b/plugins/mapbox.js
@@ -1,9 +1,0 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import Vue from 'vue'
-import { MglMap, MglGeolocateControl, MglMarker, MglPopup } from 'vue-mapbox'
-import MapLibre from 'maplibre-gl'
-Vue.component('MglMap', MglMap)
-Vue.component('MglGeolocateControl', MglGeolocateControl)
-Vue.component('MglMarker', MglMarker)
-Vue.component('MglPopup', MglPopup)
-Vue.prototype.$mapbox = MapLibre

--- a/test-unit/components/PrintableMap.markers.spec.js
+++ b/test-unit/components/PrintableMap.markers.spec.js
@@ -3,18 +3,33 @@ import PrintableMap from '~/components/PrintableMap.vue';
 
 // PrintableMap のうち、地図ライブラリに依存しない部分を固定する。
 // 表示範囲での絞り込みとカテゴリ分類は、印刷される POI 一覧の中身を決めているので、
-// ここが壊れると紙の内容が変わる。地図の生成方法とは独立しているため、
-// 地図コンポーネントはスタブに置き換えてマウントする。
+// ここが壊れると紙の内容が変わる。地図の生成方法とは独立している。
 
 jest.mock('ky', () => ({ default: { get: () => ({ text: async () => '' }) } }));
+
+// vue-mapbox を撤去したので、このコンポーネントは自分で maplibre の Map を作る。
+// この spec は地図に関心がないが、モックしないと jsdom で WebGL 初期化が失敗して
+// 未処理のリジェクトになる（jest は落とさないが vitest は落とす）。
+jest.mock('maplibre-gl', () => {
+  const actual = jest.requireActual('maplibre-gl');
+  // maplibre-gl 1.x は UMD なので実体が default の下に来ることがある
+  const base = actual.default ?? actual;
+  // eslint-disable-next-line global-require
+  const m = require('../mocks/maplibreMock');
+  const mocked = {
+    ...base,
+    Map: m.MockMap,
+    Marker: m.MockMarker,
+    Popup: m.MockPopup,
+    NavigationControl: m.MockNavigationControl,
+    GeolocateControl: m.MockGeolocateControl,
+  };
+  return { ...mocked, default: mocked };
+});
 
 const MAP_STUBS = {
   'client-only': { template: '<div><slot /></div>' },
   simplebar: { template: '<div><slot /></div>' },
-  MglMap: { template: '<div><slot /></div>' },
-  MglMarker: { template: '<div><slot /></div>' },
-  MglPopup: { template: '<div><slot /></div>' },
-  MglGeolocateControl: { template: '<div />' },
 };
 
 const mapConfig = () => ({
@@ -76,8 +91,10 @@ const factory = async (data = {}) => {
 };
 
 describe('PrintableMap の表示対象の絞り込み', () => {
+  // 地図が出来ると load() が bounds を入れるので、明示的に null に戻して確認する
   test('bounds が無いときは全てのマーカーを対象にする', async () => {
     const wrapper = await factory();
+    await wrapper.setData({ bounds: null });
     expect(wrapper.vm.inBoundsMarkers).toHaveLength(4);
   });
 

--- a/test-unit/components/PrintableMap.vue.spec.js
+++ b/test-unit/components/PrintableMap.vue.spec.js
@@ -1,0 +1,269 @@
+import { mount } from '@vue/test-utils';
+
+// maplibre-gl は WebGL を要求するので Map / Marker / Popup / 各 Control を差し替える。
+// LngLat と LngLatBounds は MapHelper が bounds 計算に使うため本物を残す。
+const mapInstances = [];
+const markerInstances = [];
+const popupInstances = [];
+
+class MockMap {
+  constructor(options) {
+    this.options = options;
+    this.handlers = {};
+    this.controls = [];
+    this.fitBoundsCalls = [];
+    this.removed = false;
+    mapInstances.push(this);
+  }
+
+  on(event, cb) {
+    (this.handlers[event] = this.handlers[event] || []).push(cb);
+    return this;
+  }
+
+  fire(event) {
+    (this.handlers[event] || []).forEach((cb) => cb());
+  }
+
+  addControl(control) {
+    this.controls.push(control);
+    return this;
+  }
+
+  fitBounds(bounds, options) {
+    this.fitBoundsCalls.push({ bounds, options });
+    return this;
+  }
+
+  getBounds() {
+    const MapLibre = jest.requireActual('maplibre-gl');
+    return new MapLibre.LngLatBounds(
+      new MapLibre.LngLat(130.6, 32.5),
+      new MapLibre.LngLat(130.8, 32.7)
+    );
+  }
+
+  remove() {
+    this.removed = true;
+  }
+}
+
+class MockMarker {
+  constructor(options) {
+    this.options = options;
+    this.lngLat = null;
+    this.popup = null;
+    this.addedTo = null;
+    this.removed = false;
+    markerInstances.push(this);
+  }
+
+  setLngLat(lngLat) {
+    this.lngLat = lngLat;
+    return this;
+  }
+
+  setPopup(popup) {
+    this.popup = popup;
+    return this;
+  }
+
+  addTo(map) {
+    this.addedTo = map;
+    return this;
+  }
+
+  remove() {
+    this.removed = true;
+    return this;
+  }
+}
+
+class MockPopup {
+  constructor(options) {
+    this.options = options;
+    this.dom = null;
+    this.html = null;
+    popupInstances.push(this);
+  }
+
+  setDOMContent(dom) {
+    this.dom = dom;
+    return this;
+  }
+
+  setHTML(html) {
+    this.html = html;
+    return this;
+  }
+}
+
+class MockNavigationControl {}
+class MockGeolocateControl {
+  constructor(options) {
+    this.options = options;
+  }
+}
+
+// ky は ESM で配布されており node_modules は変換対象外のため require できない。
+// このテストでは sources を空にして通信を起こさないので、存在するだけでよい。
+jest.mock('ky', () => ({ default: { get: () => ({ text: async () => '' }) } }));
+
+jest.mock('maplibre-gl', () => {
+  const actual = jest.requireActual('maplibre-gl');
+  return {
+    ...actual,
+    Map: MockMap,
+    Marker: MockMarker,
+    Popup: MockPopup,
+    NavigationControl: MockNavigationControl,
+    GeolocateControl: MockGeolocateControl,
+  };
+});
+
+// eslint-disable-next-line import/first
+import PrintableMap from '~/components/PrintableMap.vue';
+
+const MAP_STYLE = 'https://tile.openstreetmap.jp/styles/maptiler-basic-ja/style.json';
+const DEFAULT_HASH = '32.7,130.6-32.5,130.8';
+
+const mapConfig = () => ({
+  map_id: 'test',
+  map_title: 'テスト',
+  center: [130.7, 32.6],
+  default_hash: DEFAULT_HASH,
+  type: 'geojson',
+  sources: [], // 空にして mounted 内の fetch を起こさない
+  layer_settings: {
+    給水: { name: '給水', color: '#285797', bg_color: '#A3BBDA', icon_class: 'fa-solid fa-droplet' },
+  },
+});
+
+const marker = (lng, lat, name) => ({
+  category: '給水',
+  feature: {
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [lng, lat] },
+    properties: { name },
+  },
+});
+
+const LAYER = {
+  source: { id: 'test', title: 'テスト', type: 'geojson', show: true, url: 'http://example.test/a.geojson' },
+  markers: [marker(130.7, 32.6, '氷川町役場'), marker(130.68, 32.55, '宮原振興局')],
+};
+
+const factory = async (overrides = {}) => {
+  const wrapper = mount(PrintableMap, {
+    propsData: { mapConfig: mapConfig() },
+    stubs: { 'client-only': { template: '<div><slot /></div>' }, simplebar: { template: '<div><slot /></div>' } },
+    mocks: { $i18n: { locale: 'ja', t: (key) => key } },
+    ...overrides,
+  });
+  // layers が空だと地図コンテナが描画されない（template の v-if='layers.length'）。
+  // 本来は mounted 内の非同期取得で埋まるので、テストでは直接与える。
+  await wrapper.setData({ layers: [LAYER], checkedArea: ['テスト'] });
+  await wrapper.vm.$nextTick();
+  return wrapper;
+};
+
+beforeEach(() => {
+  mapInstances.length = 0;
+  markerInstances.length = 0;
+  popupInstances.length = 0;
+  window.location.hash = '';
+});
+
+describe('PrintableMap の地図生成', () => {
+  test('layers が入ると maplibre の Map が1つ生成される', async () => {
+    await factory();
+    expect(mapInstances).toHaveLength(1);
+  });
+
+  test('preserveDrawingBuffer: true が渡る（印刷で canvas を読み戻すため必須）', async () => {
+    await factory();
+    expect(mapInstances[0].options.preserveDrawingBuffer).toBe(true);
+  });
+
+  test('style / center / zoom が渡る', async () => {
+    await factory();
+    const { style, center, zoom } = mapInstances[0].options;
+    expect(style).toBe(MAP_STYLE);
+    expect(center).toEqual([130.7, 32.6]);
+    expect(zoom).toBe(15);
+  });
+
+  test('container に地図用の要素が渡る', async () => {
+    await factory();
+    expect(mapInstances[0].options.container).toBeTruthy();
+  });
+
+  test('NavigationControl と GeolocateControl が追加される', async () => {
+    await factory();
+    const kinds = mapInstances[0].controls.map((c) => c.constructor.name);
+    expect(kinds).toContain('MockNavigationControl');
+    expect(kinds).toContain('MockGeolocateControl');
+  });
+});
+
+describe('PrintableMap の表示範囲', () => {
+  test('URL ハッシュが無いときは default_hash で fitBounds する', async () => {
+    await factory();
+    expect(mapInstances[0].fitBoundsCalls).toHaveLength(1);
+    const b = mapInstances[0].fitBoundsCalls[0].bounds;
+    const lats = [b.getNorthEast().lat, b.getSouthWest().lat];
+    expect(Math.min(...lats)).toBeCloseTo(32.5, 6);
+    expect(Math.max(...lats)).toBeCloseTo(32.7, 6);
+  });
+
+  test('URL ハッシュがあればそちらを優先して fitBounds する', async () => {
+    window.location.hash = '#33.1,131.1-33.0,131.2';
+    await factory();
+    const b = mapInstances[0].fitBoundsCalls[0].bounds;
+    const lngs = [b.getNorthEast().lng, b.getSouthWest().lng];
+    expect(Math.min(...lngs)).toBeCloseTo(131.1, 6);
+    expect(Math.max(...lngs)).toBeCloseTo(131.2, 6);
+  });
+
+  test('moveend で bounds-changed を emit する', async () => {
+    const wrapper = await factory();
+    expect(mapInstances[0].handlers.moveend).toBeDefined();
+    mapInstances[0].fire('moveend');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted('bounds-changed')).toBeTruthy();
+  });
+});
+
+describe('PrintableMap のマーカー', () => {
+  test('表示対象のマーカーごとに Marker が生成され地図に追加される', async () => {
+    await factory();
+    const added = markerInstances.filter((m) => m.addedTo);
+    expect(added).toHaveLength(LAYER.markers.length);
+    expect(added[0].lngLat).toEqual([130.7, 32.6]);
+  });
+
+  test('マーカーには Popup が設定される', async () => {
+    await factory();
+    const withPopup = markerInstances.filter((m) => m.popup);
+    expect(withPopup).toHaveLength(LAYER.markers.length);
+  });
+
+  test('表示対象から外れたマーカーは地図から取り除かれる', async () => {
+    const wrapper = await factory();
+    const before = markerInstances.filter((m) => m.addedTo).length;
+    // 1件だけになるよう絞る
+    await wrapper.setData({ layers: [{ ...LAYER, markers: [LAYER.markers[0]] }] });
+    await wrapper.vm.$nextTick();
+    const removed = markerInstances.filter((m) => m.removed).length;
+    expect(before).toBe(2);
+    expect(removed).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('PrintableMap の破棄', () => {
+  test('コンポーネント破棄時に map.remove() される', async () => {
+    const wrapper = await factory();
+    wrapper.destroy();
+    expect(mapInstances[0].removed).toBe(true);
+  });
+});

--- a/test-unit/components/PrintableMap.vue.spec.js
+++ b/test-unit/components/PrintableMap.vue.spec.js
@@ -1,127 +1,29 @@
 import { mount } from '@vue/test-utils';
 
-// maplibre-gl は WebGL を要求するので Map / Marker / Popup / 各 Control を差し替える。
-// LngLat と LngLatBounds は MapHelper が bounds 計算に使うため本物を残す。
-const mapInstances = [];
-const markerInstances = [];
-const popupInstances = [];
-
-class MockMap {
-  constructor(options) {
-    this.options = options;
-    this.handlers = {};
-    this.controls = [];
-    this.fitBoundsCalls = [];
-    this.removed = false;
-    mapInstances.push(this);
-  }
-
-  on(event, cb) {
-    (this.handlers[event] = this.handlers[event] || []).push(cb);
-    return this;
-  }
-
-  fire(event) {
-    (this.handlers[event] || []).forEach((cb) => cb());
-  }
-
-  addControl(control) {
-    this.controls.push(control);
-    return this;
-  }
-
-  fitBounds(bounds, options) {
-    this.fitBoundsCalls.push({ bounds, options });
-    return this;
-  }
-
-  getBounds() {
-    const MapLibre = jest.requireActual('maplibre-gl');
-    return new MapLibre.LngLatBounds(
-      new MapLibre.LngLat(130.6, 32.5),
-      new MapLibre.LngLat(130.8, 32.7)
-    );
-  }
-
-  remove() {
-    this.removed = true;
-  }
-}
-
-class MockMarker {
-  constructor(options) {
-    this.options = options;
-    this.lngLat = null;
-    this.popup = null;
-    this.addedTo = null;
-    this.removed = false;
-    markerInstances.push(this);
-  }
-
-  setLngLat(lngLat) {
-    this.lngLat = lngLat;
-    return this;
-  }
-
-  setPopup(popup) {
-    this.popup = popup;
-    return this;
-  }
-
-  addTo(map) {
-    this.addedTo = map;
-    return this;
-  }
-
-  remove() {
-    this.removed = true;
-    return this;
-  }
-}
-
-class MockPopup {
-  constructor(options) {
-    this.options = options;
-    this.dom = null;
-    this.html = null;
-    popupInstances.push(this);
-  }
-
-  setDOMContent(dom) {
-    this.dom = dom;
-    return this;
-  }
-
-  setHTML(html) {
-    this.html = html;
-    return this;
-  }
-}
-
-class MockNavigationControl {}
-class MockGeolocateControl {
-  constructor(options) {
-    this.options = options;
-  }
-}
-
 // ky は ESM で配布されており node_modules は変換対象外のため require できない。
 // このテストでは sources を空にして通信を起こさないので、存在するだけでよい。
 jest.mock('ky', () => ({ default: { get: () => ({ text: async () => '' }) } }));
 
+// maplibre-gl は WebGL を要求するので Map / Marker / Popup / 各 Control を差し替える。
+// LngLat と LngLatBounds は MapHelper が bounds 計算に使うため本物を残す。
 jest.mock('maplibre-gl', () => {
   const actual = jest.requireActual('maplibre-gl');
-  return {
+  const m = require('../mocks/maplibreMock');
+  const mocked = {
     ...actual,
-    Map: MockMap,
-    Marker: MockMarker,
-    Popup: MockPopup,
-    NavigationControl: MockNavigationControl,
-    GeolocateControl: MockGeolocateControl,
+    Map: m.MockMap,
+    Marker: m.MockMarker,
+    Popup: m.MockPopup,
+    NavigationControl: m.MockNavigationControl,
+    GeolocateControl: m.MockGeolocateControl,
   };
+  // PrintableMap は `import MapLibre from` で default を、
+  // MapHelper は `import * as MapLibre` で名前空間を見るため両方を満たす形にする。
+  return { ...mocked, default: mocked, __esModule: true };
 });
 
-// eslint-disable-next-line import/first
+import { mapInstances, markerInstances, resetInstances } from '../mocks/maplibreMock';
+
 import PrintableMap from '~/components/PrintableMap.vue';
 
 const MAP_STYLE = 'https://tile.openstreetmap.jp/styles/maptiler-basic-ja/style.json';
@@ -157,7 +59,7 @@ const factory = async (overrides = {}) => {
   const wrapper = mount(PrintableMap, {
     propsData: { mapConfig: mapConfig() },
     stubs: { 'client-only': { template: '<div><slot /></div>' }, simplebar: { template: '<div><slot /></div>' } },
-    mocks: { $i18n: { locale: 'ja', t: (key) => key } },
+    mocks: { $i18n: { locale: 'ja', t: (key) => key }, $t: (key) => key },
     ...overrides,
   });
   // layers が空だと地図コンテナが描画されない（template の v-if='layers.length'）。
@@ -168,9 +70,7 @@ const factory = async (overrides = {}) => {
 };
 
 beforeEach(() => {
-  mapInstances.length = 0;
-  markerInstances.length = 0;
-  popupInstances.length = 0;
+  resetInstances();
   window.location.hash = '';
 });
 

--- a/test-unit/mocks/maplibreMock.js
+++ b/test-unit/mocks/maplibreMock.js
@@ -1,0 +1,114 @@
+// maplibre-gl の Map / Marker / Popup / 各 Control の差し替え。
+// jest.mock のファクトリはファイル先頭に巻き上げられるため、テストファイル内で
+// class を宣言すると参照時点で undefined になる。別モジュールに置いて
+// ファクトリ内から require することで確実に解決させる。
+
+export const mapInstances = [];
+export const markerInstances = [];
+export const popupInstances = [];
+
+export const resetInstances = () => {
+  mapInstances.length = 0;
+  markerInstances.length = 0;
+  popupInstances.length = 0;
+};
+
+export class MockMap {
+  constructor(options) {
+    this.options = options;
+    this.handlers = {};
+    this.controls = [];
+    this.fitBoundsCalls = [];
+    this.removed = false;
+    mapInstances.push(this);
+  }
+
+  on(event, cb) {
+    (this.handlers[event] = this.handlers[event] || []).push(cb);
+    return this;
+  }
+
+  fire(event) {
+    (this.handlers[event] || []).forEach((cb) => cb());
+  }
+
+  addControl(control) {
+    this.controls.push(control);
+    return this;
+  }
+
+  fitBounds(bounds, options) {
+    this.fitBoundsCalls.push({ bounds, options });
+    return this;
+  }
+
+  getBounds() {
+    const MapLibre = jest.requireActual('maplibre-gl');
+    return new MapLibre.LngLatBounds(
+      new MapLibre.LngLat(130.6, 32.5),
+      new MapLibre.LngLat(130.8, 32.7)
+    );
+  }
+
+  remove() {
+    this.removed = true;
+  }
+}
+
+export class MockMarker {
+  constructor(options) {
+    this.options = options;
+    this.lngLat = null;
+    this.popup = null;
+    this.addedTo = null;
+    this.removed = false;
+    markerInstances.push(this);
+  }
+
+  setLngLat(lngLat) {
+    this.lngLat = lngLat;
+    return this;
+  }
+
+  setPopup(popup) {
+    this.popup = popup;
+    return this;
+  }
+
+  addTo(map) {
+    this.addedTo = map;
+    return this;
+  }
+
+  remove() {
+    this.removed = true;
+    return this;
+  }
+}
+
+export class MockPopup {
+  constructor(options) {
+    this.options = options;
+    this.dom = null;
+    this.html = null;
+    popupInstances.push(this);
+  }
+
+  setDOMContent(dom) {
+    this.dom = dom;
+    return this;
+  }
+
+  setHTML(html) {
+    this.html = html;
+    return this;
+  }
+}
+
+export class MockNavigationControl {}
+
+export class MockGeolocateControl {
+  constructor(options) {
+    this.options = options;
+  }
+}

--- a/test-unit/mocks/maplibreMock.js
+++ b/test-unit/mocks/maplibreMock.js
@@ -42,12 +42,16 @@ export class MockMap {
     return this;
   }
 
+  // inBounds() は getNorthEast / getSouthWest、serializeBounds() は
+  // getNorthWest / getSouthEast を使う。この4つを満たせば maplibre の実物は不要
+  // （テストランナー非依存に保つため実物を持ち込まない）。
   getBounds() {
-    const MapLibre = jest.requireActual('maplibre-gl');
-    return new MapLibre.LngLatBounds(
-      new MapLibre.LngLat(130.6, 32.5),
-      new MapLibre.LngLat(130.8, 32.7)
-    );
+    return {
+      getNorthEast: () => ({ lng: 130.8, lat: 32.7 }),
+      getSouthWest: () => ({ lng: 130.6, lat: 32.5 }),
+      getNorthWest: () => ({ lng: 130.6, lat: 32.7 }),
+      getSouthEast: () => ({ lng: 130.8, lat: 32.5 }),
+    };
   }
 
   remove() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10563,11 +10563,6 @@ map-cache@^0.2.2:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==
 
-map-promisified@latest:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/map-promisified/-/map-promisified-0.4.0.tgz#c33cc8b93d2d28b0df0b0937ffabcd145b9b9a82"
-  integrity sha512-VYBQ3rTMykg2CSVgSrZBvhAwxuIuYbAHCtjjq/ATnD5kMq7I/ROmMBckwlmfwtEIx9yXufF+3QY5WxUH5EeM/Q==
-
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
@@ -15743,13 +15738,6 @@ vue-loader@^15.11.1:
     loader-utils "^1.1.0"
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
-
-vue-mapbox@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/vue-mapbox/-/vue-mapbox-0.4.1.tgz#c1cac11c33c46a78a2b58797686371a4c32ffb4a"
-  integrity sha512-F1ebtVpRSvl6HDiHCWm5TxBNDy5WCoNJOZWj4ub6XQzht15GfUpAn4bHIeVzrUHr3fi1PFEDbxnzPeG1S9o0Tg==
-  dependencies:
-    map-promisified latest
 
 vue-meta@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## 概要 | About

vue-mapbox を撤去して maplibre-gl を直接使うようにします。
Nuxt 4 移行の前提となる変更ですが、単独でも意味があるので分けて出しています。

base は #558（テスト追加）です。
そちらがマージされると base が master に切り替わります。

#558 がマージされるまでは Draft にしておきます。

vue-mapbox は Vue 2 専用で最終公開が 2022年5月です。Vue 3 では動かないため、Nuxt 4 に上げるには撤去が必要です。

撤去できるのは、すでに実質コンテナとしてしか使っていなかったためです。`components/PrintableMap.vue` は `import MapLibre from "maplibre-gl"` を持っていて、`this.map.map.fitBounds()` `this.map.map.on()` `this.map.map.addControl()` のように `.map` で生インスタンスに降りて操作していました。vue-mapbox が担っていたのは `MglMap` / `MglGeolocateControl` / `MglMarker` / `MglPopup` の4つだけです。

実装の方針

- マーカーは **Vue が描画した DOM の複製**を maplibre に渡します。元要素をそのまま渡すと Vue の管理下から DOM が移動して patch が壊れるためです。これにより pug テンプレート内のアイコン・色・番号・i18n・ポップアップ本文のロジックがそのまま残っています
- マーカーは座標・カテゴリ・名称を鍵にした差分更新です。地図移動のたびに全消しせず、消えた分だけ `remove()` します。凡例のカテゴリ選択時だけ複製を作り直します（クリック起点なのでちらつきは問題になりません）
- `Map` と `Marker` のインスタンスは Vue のリアクティブ data に置かず `created()` で非リアクティブに持ちます。Vue が WebGL 由来のオブジェクトを深く走査してしまうためです
- `maplibre-gl` のバージョンは据え置き（1.15.3）です。6系への更新は別PRにします

契約テスト12件を先に書いて落ちることを確認してから実装しました。とくに **`preserveDrawingBuffer: true`** は、落とすと画面では正常に見えるのに印刷結果の地図だけが白くなるため、テストで固定しています。

`test-unit/components/PrintableMap.markers.spec.js`（#558 で追加したもの）に maplibre のモックを足しています。vue-mapbox を撤去するとこのコンポーネントが自分で地図を作るようになり、モックなしでは jsdom で WebGL 初期化に失敗するためです。

## 動作確認方法 | How to check

```
yarn install
yarn test:unit   # 7 suites / 47 tests passed
yarn run lint    # 0 errors
yarn run generate --fail-on-error
```

Vercel preview（fork 側の PR: yuiseki/mapprint#23）

https://mapprint-git-yuiseki-rm-vue-mapbox-yuiseki-s-team.vercel.app/map/2024-noto-earthquake

こちらで確認済みのこと

- マーカーの位置とポップアップ、凡例のカテゴリ切り替え、地図移動時の URL ハッシュと下部一覧の連動
- **実際に PDF 印刷して地図が白くならないことを確認しました**（下記）
- Playwright での自動確認 7/7（canvas 生成、マーカー86件、ポップアップ、canvas のピクセル読み戻し、印刷メディアでの canvas サイズ、凡例クリックでの表示切替）

## スクリーンショット | Screenshot

### Before

[![Image from Gyazo](https://i.gyazo.com/ede7df7db0c4f5ac50c054c20006b230.png)](https://gyazo.com/ede7df7db0c4f5ac50c054c20006b230)

### After

[![Image from Gyazo](https://i.gyazo.com/d2179f4eac031c75f19f36148f4027fc.png)](https://gyazo.com/d2179f4eac031c75f19f36148f4027fc)

### Diff

[![Image from Gyazo](https://i.gyazo.com/9bbe557d00ae729d5594cc4257b1323d.png)](https://gyazo.com/9bbe557d00ae729d5594cc4257b1323d)

1920x1925 で比較して 97.5% のピクセルが完全一致、平均絶対差 0.94/255 でした。
赤くなっているのは文字のアンチエイリアスだけです。上部ヘッダは 0.00%、地図領域は 0.66%（マーカー番号の文字）で、マーカーの位置と地図の形状はピクセル単位で一致しています。

### 印刷結果（PDF）

[![Image from Gyazo](https://i.gyazo.com/7338a6715cafafb96ce0bd3f5edb52c8.png)](https://gyazo.com/7338a6715cafafb96ce0bd3f5edb52c8)

地図・QRコード・カテゴリ別の一覧が出ていて、`print-exclude` の要素（凡例ナビ・シェアボタン・言語選択）は消えています。
地図領域は 2,653色・標準偏差 33.0 で、白紙なら1色・標準偏差0になります。
