### PR TITLE
fix(map): 印刷される一覧の並び順を取得の完了順に依存させない

### DIFF
--- a/components/PrintableMap.vue
+++ b/components/PrintableMap.vue
@@ -231,16 +231,18 @@ export default {
     const MapHelper = require("~/lib/MapHelper.ts").default;
     const ky = require("ky").default;
     helper = new MapHelper();
-    const area = [];
     const categories = {};
     const self = this;
-    this.mapConfig.sources.forEach((source) => {
+    // 取得の完了順ではなく mapConfig.sources の順序で並べる。印刷される一覧の
+    // 番号は layers を順に辿って振られるので、完了順に入れると回線の速さで
+    // 同じ地点に違う番号が付き、刷り直した紙どうしが食い違う。
+    this.layers = this.mapConfig.sources.map((source) => ({ source, markers: [] }));
+    this.checkedArea = this.mapConfig.sources
+      .filter((source) => source.show)
+      .map((source) => source.title);
+    this.updated_at = getNowYMD(new Date());
+    this.mapConfig.sources.forEach((source, index) => {
       (async () => {
-        if (source.show) {
-          area.push(source.title);
-        }
-        self.checkedArea = area;
-        self.updated_at = getNowYMD(new Date());
         const data = await ky.get(source.url).text();
         const [markers, updated_at] = helper.parse(
           source.type,
@@ -274,7 +276,8 @@ export default {
             })
           }
         });
-        self.layers.push({
+        // 位置は取得を始めた時点で決まっているので、完了順に影響されない
+        self.$set(self.layers, index, {
           source,
           markers,
         });

--- a/test-unit/components/PrintableMap.layerOrder.spec.js
+++ b/test-unit/components/PrintableMap.layerOrder.spec.js
@@ -1,0 +1,131 @@
+import { mount } from '@vue/test-utils';
+import PrintableMap from '~/components/PrintableMap.vue';
+
+// 印刷される一覧の番号は layers を順に辿って振られる。
+// layers が取得の完了順に並ぶと、同じ地点に開くたび違う番号が付き、
+// 刷り直した紙どうしが食い違う。ここでは完了順をわざと逆にして、
+// それでも layers が mapConfig.sources の順序になることを固定する。
+jest.mock('ky', () => {
+  const ticks = (count) => {
+    let promise = Promise.resolve();
+    for (let i = 0; i < count; i += 1) {
+      promise = promise.then();
+    }
+    return promise;
+  };
+  const geojson = (name) =>
+    JSON.stringify({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: { name, category: '給水' },
+          geometry: { type: 'Point', coordinates: [130.7, 32.6] },
+        },
+      ],
+    });
+  return {
+    default: {
+      get: (url) => ({
+        text: async () => {
+          const slow = url.indexOf('slow') >= 0;
+          // 先に書いてあるソースをあとから返す
+          await ticks(slow ? 8 : 1);
+          global.__kyCompletionOrder.push(slow ? 'slow' : 'fast');
+          return geojson(slow ? '遅い方の地点' : '速い方の地点');
+        },
+      }),
+    },
+  };
+});
+
+const MAP_STUBS = {
+  'client-only': { template: '<div><slot /></div>' },
+  simplebar: { template: '<div><slot /></div>' },
+  MglMap: { template: '<div><slot /></div>' },
+  MglMarker: { template: '<div><slot /></div>' },
+  MglPopup: { template: '<div><slot /></div>' },
+  MglGeolocateControl: { template: '<div />' },
+};
+
+const source = (id, title, show = true) => ({
+  id,
+  title,
+  type: 'geojson',
+  show,
+  url: 'http://example.test/' + id,
+});
+
+const mapConfig = (sources) => ({
+  map_id: 'test',
+  map_title: 'テスト',
+  center: [130.7, 32.6],
+  default_hash: '32.7,130.6-32.5,130.8',
+  type: 'geojson',
+  sources,
+  layer_settings: {
+    給水: { name: '給水所', color: '#285797', bg_color: '#A3BBDA' },
+  },
+});
+
+const flush = async (count) => {
+  for (let i = 0; i < count; i += 1) {
+    await Promise.resolve();
+  }
+};
+
+const factory = (sources) =>
+  mount(PrintableMap, {
+    propsData: { mapConfig: mapConfig(sources) },
+    stubs: MAP_STUBS,
+    mocks: { $i18n: { locale: 'ja', t: (key) => key }, $t: (key) => key },
+  });
+
+beforeEach(() => {
+  global.__kyCompletionOrder = [];
+});
+
+describe('PrintableMap のレイヤーの並び順', () => {
+  test('取得が逆順に終わっても layers は sources の順序になる', async () => {
+    const wrapper = factory([source('slow', '遅いソース'), source('fast', '速いソース')]);
+    await flush(40);
+
+    // 前提として、完了順は逆になっている
+    expect(global.__kyCompletionOrder).toEqual(['fast', 'slow']);
+
+    expect(wrapper.vm.layers.map((layer) => layer.source.id)).toEqual(['slow', 'fast']);
+    expect(wrapper.vm.layers.map((layer) => layer.markers.length)).toEqual([1, 1]);
+  });
+
+  test('一覧の番号が sources の順序で振られる', async () => {
+    const wrapper = factory([source('slow', '遅いソース'), source('fast', '速いソース')]);
+    await flush(40);
+
+    const names = wrapper.vm.inBoundsMarkers.map((marker) => marker.feature.properties.name);
+    expect(names).toEqual(['遅い方の地点', '速い方の地点']);
+  });
+
+  test('先に取れたソースを待たせない', async () => {
+    const wrapper = factory([source('slow', '遅いソース'), source('fast', '速いソース')]);
+    await flush(6);
+
+    // 速い方だけが入っていて、遅い方の位置は空のまま確保されている
+    expect(global.__kyCompletionOrder).toEqual(['fast']);
+    expect(wrapper.vm.layers.map((layer) => layer.source.id)).toEqual(['slow', 'fast']);
+    expect(wrapper.vm.layers.map((layer) => layer.markers.length)).toEqual([0, 1]);
+  });
+
+  // checkedArea は修正前から sources の順序だった（push が最初の await より前に
+  // 走るため）。ここは不具合の再現ではなく、構築の位置を mounted の頭へ移した
+  // 整理で中身が変わっていないことを固定するためのもの。
+  test('チェック済みエリアも sources の順序で、show が false のものは入らない', async () => {
+    const wrapper = factory([
+      source('slow', '遅いソース'),
+      source('hidden', '出さないソース', false),
+      source('fast', '速いソース'),
+    ]);
+    await flush(40);
+
+    expect(wrapper.vm.checkedArea).toEqual(['遅いソース', '速いソース']);
+  });
+});


### PR DESCRIPTION
## 概要 | About

Fix: #561

`layers` に取得できた順で `push` していたため、回線の速さで並びが変わっていました。印刷される一覧の番号は `layers` を順に辿って振られるので、同じ地点に開くたび違う番号が付きます。

`mounted()` の頭で `mapConfig.sources` の順序どおりに `layers` の位置を確保し、取得が終わったソースをその位置へ入れる形にしました。Issue に書かれていた「`forEach` の添字で位置を決める」案です。取れたものから順に地図へ出る挙動は変えていないので、細い回線でも表示の開始は遅くなりません。

`checkedArea` の構築も `mounted()` の頭へ移しました。こちらは `push` が最初の `await` より前に走るので**元から `sources` の順序**で、挙動は変わっていません（不具合ではなく整理です）。

## 動作確認方法 | How to check

`test-unit/components/PrintableMap.layerOrder.spec.js` を追加しました。`ky` を差し替えて、**あとに書いたソースを先に返させます**。完了順はマイクロタスクを何段挟むかで決めているので、実行環境の速さに左右されません。

```
yarn test:unit
```

固定している内容です。

| テスト | 内容 |
|---|---|
| 取得が逆順に終わっても layers は sources の順序になる | 完了順が `fast` → `slow` でも `layers` は `slow` → `fast` |
| 一覧の番号が sources の順序で振られる | `inBoundsMarkers` の並びが `sources` の順序 |
| 先に取れたソースを待たせない | 速い方だけ入った時点で、遅い方の位置は空のまま確保されている |
| チェック済みエリアも sources の順序で、show が false のものは入らない | 上記の整理で中身が変わっていないことの確認 |

**修正を外すと 4 件中 3 件が落ちます**（`checkedArea` の 1 件は元から壊れていないので通ります。その旨をテスト内にコメントしてあります）。

手元の結果です。

- `yarn test:unit` — 7 suites / 39 tests passed
- `yarn lint` — 0 errors（既存の warning 26 件のみ）

## スクリーンショット | Screenshot

なし（見た目は変わりません）。

## base について

テストが #558 で入る `jest.setup.js` とモックを使うため、`yuiseki-add-tests-2026-07` を base にしています。#558 が master に入ったあとであれば master へ付け替えていただいて問題ありません。
