### PR TITLE
feat: 令和8年熊本地震の紙マップを追加する

### DIFF
--- a/assets/config/2026-kumamoto-earthquake.json
+++ b/assets/config/2026-kumamoto-earthquake.json
@@ -1,0 +1,111 @@
+{
+  "map_id": "2026-kumamoto-earthquake",
+  "map_title": "令和8年熊本地震関連情報",
+  "map_title_en": "Kumamoto Earthquake Information (2026)",
+  "map_description": "令和8年熊本地震の被災地の支援情報を、印刷に最適化して表示するマップです。給水所・避難所・入浴施設・ガソリンスタンドなどが載っています。マップを必要な地域のところに調整すると、A4サイズにちょうどよく印刷され、かつ必要な場所の情報がリストとして表示されます。ぜひ印刷して必要な人に届けてあげてください！ 各地点の出典と時刻は吹き出しに書いてあります。",
+  "map_description_en": "This map shows support information for the areas hit by the 2026 Kumamoto Earthquake, such as water supply points, evacuation sites, bathing facilities and gas stations. It is designed for printing, allowing those without internet access to obtain the information. Once you set the map to the desired place, you can print it in A4 size with a list of the spots in that area. Just print it and give it to anyone who needs it! The source and the time of each spot are shown in its popup.",
+  "map_image": null,
+  "sources": [
+    {
+      "id": "kumamoto_spots",
+      "url": "https://tomo3141592653.github.io/self-driving-ai-prototype/kumamoto-quake-2026/spots-geo.json",
+      "link": "https://tomo3141592653.github.io/self-driving-ai-prototype/kumamoto-quake-2026/",
+      "type": "geojson",
+      "title": "支援情報",
+      "title_en": "Support information",
+      "show": true,
+      "filter": {
+        "require": ["reuse"],
+        "include": {
+          "reuse": ["open"],
+          "status": ["open", "limited"]
+        }
+      }
+    }
+  ],
+  "default_hash": "33.05,130.00-32.17,130.96",
+  "center": [130.477714, 32.607723],
+  "type": "geojson",
+  "layer_settings": {
+    "避難所": {
+      "name": "避難所",
+      "name_en": "Evacuation site",
+      "color": "#276445",
+      "bg_color": "#A4C1B0",
+      "icon_class": "fa-solid fa-street-view",
+      "class": "layer_shelter"
+    },
+    "給水": {
+      "name": "給水所",
+      "name_en": "Water supply",
+      "color": "#285797",
+      "bg_color": "#A3BBDA",
+      "icon_class": "fa-solid fa-droplet",
+      "class": "layer_water"
+    },
+    "入浴・シャワー": {
+      "name": "入浴・シャワー",
+      "name_en": "Bath and shower",
+      "color": "#C43895",
+      "bg_color": "#F9B3E2",
+      "icon_class": "fa-solid fa-shower",
+      "class": "layer_shower"
+    },
+    "医療・薬局": {
+      "name": "医療・薬局",
+      "name_en": "Medical and pharmacy",
+      "color": "#992222",
+      "bg_color": "#CA9491",
+      "icon_class": "fa-solid fa-kit-medical",
+      "class": "layer_medical"
+    },
+    "トイレ・炊き出し": {
+      "name": "トイレ・炊き出し",
+      "name_en": "Toilet and hot meals",
+      "color": "#6D4615",
+      "bg_color": "#C1B17E",
+      "icon_class": "fa-solid fa-restroom",
+      "class": "layer_toilet"
+    },
+    "ガソリンスタンド": {
+      "name": "ガソリンスタンド",
+      "name_en": "Gas station",
+      "color": "#A33D0B",
+      "bg_color": "#E3B49B",
+      "icon_class": "fa-solid fa-gas-pump",
+      "class": "layer_gas_station"
+    },
+    "充電・通信": {
+      "name": "充電・通信",
+      "name_en": "Charging and connectivity",
+      "color": "#4B3C8F",
+      "bg_color": "#B9B2DF",
+      "icon_class": "fa-solid fa-plug",
+      "class": "layer_charger"
+    },
+    "行政手続き": {
+      "name": "行政手続き",
+      "name_en": "Administrative procedures",
+      "color": "#4F4F5A",
+      "bg_color": "#B7B7BE",
+      "icon_class": "fa-solid fa-building-columns",
+      "class": "layer_administration"
+    },
+    "コンビニ・スーパー": {
+      "name": "コンビニ・スーパー",
+      "name_en": "Convenience store and supermarket",
+      "color": "#0F6E6E",
+      "bg_color": "#A5CFCF",
+      "icon_class": "fa-solid fa-cart-shopping",
+      "class": "layer_store"
+    },
+    "金融": {
+      "name": "金融",
+      "name_en": "Bank and ATM",
+      "color": "#7A5C00",
+      "bg_color": "#DBC98A",
+      "icon_class": "fa-solid fa-yen-sign",
+      "class": "layer_bank"
+    }
+  }
+}

--- a/assets/config/list.json
+++ b/assets/config/list.json
@@ -1,4 +1,5 @@
 [
+  "2026-kumamoto-earthquake.json",
   "2024-noto-earthquake.json",
   "2019-typhoon-19.json",
   "2019-chiba-typhoon-15.json",

--- a/components/PrintableMap.vue
+++ b/components/PrintableMap.vue
@@ -138,6 +138,7 @@ import ky from "ky";
 // js-crc は CommonJS なので named import は SSR で解決できない
 import jsCrc from "js-crc";
 import { getNowYMD } from "~/lib/displayHelper";
+import { filterMarkers } from "~/lib/sourceFilter";
 import MapHelper from "~/lib/MapHelper";
 // Vite では require が使えないため、ロケール別の画像は静的に import する
 import fukidashiJa from "~/assets/images/fukidashi_obj_ja.svg";
@@ -309,12 +310,13 @@ export default {
     this.mapConfig.sources.forEach((source, index) => {
       (async () => {
         const data = await ky.get(source.url).text();
-        const [markers, updated_at] = helper.parse(
+        const [parsedMarkers, updated_at] = helper.parse(
           source.type,
           data,
           self.mapConfig.layer_settings,
           source.updated_search_key
         );
+        const markers = filterMarkers(parsedMarkers, source.filter);
         // eslint-disable-next-line array-callback-return
         markers.map((marker) => {
           categories[marker.category] = true;

--- a/lib/sourceFilter.ts
+++ b/lib/sourceFilter.ts
@@ -1,0 +1,76 @@
+export type FilterValue = string | number | boolean;
+
+/**
+ * sources[] の一つに書ける絞り込みの指定。
+ *
+ * require: この名前のプロパティを持たない地物は載せない
+ * include: プロパティごとに、載せる値を並べる（並べた値以外は載せない）
+ * exclude: プロパティごとに、載せない値を並べる
+ */
+export interface SourceFilter {
+  require?: string[];
+  include?: { [property: string]: FilterValue[] };
+  exclude?: { [property: string]: FilterValue[] };
+}
+
+/**
+ * 読み込んだ地物のうち、紙に刷るものだけを残す。
+ *
+ * 紙マップは第三者が集約したデータを読むことがあり、その中には
+ * そのまま載せたくないものが混ざる。提供元のデータベースをほぼ複製した
+ * 出典や、すでに閉まっている施設がそれにあたる。データを作り直してもらう
+ * かわりに、何を載せないかを地図の設定側で宣言できるようにする。
+ *
+ * 紙は配ったあとで訂正できないので、判断がつかないときは載せない側に倒す。
+ * exclude だけを書くと、提供元がフィールド名を変えたときに一致しなくなって
+ * 黙って全件が通ってしまうため、require でそのフィールドの存在自体を
+ * 条件にできるようにしてある。
+ */
+export function filterMarkers(markers: any[], filter?: SourceFilter | null): any[] {
+  if (!filter) {
+    return markers;
+  }
+  const required = filter.require || [];
+  const include = filter.include || {};
+  const exclude = filter.exclude || {};
+
+  return markers.filter((marker) => {
+    const properties = propertiesOf(marker);
+    if (properties === null) {
+      // プロパティが読めない地物は、載せる条件を確かめようがない
+      return required.length === 0 && Object.keys(include).length === 0;
+    }
+    if (!required.every((name) => hasValue(properties[name]))) {
+      return false;
+    }
+    if (!Object.keys(include).every((name) => matches(properties[name], include[name]))) {
+      return false;
+    }
+    return !Object.keys(exclude).some((name) => matches(properties[name], exclude[name]));
+  });
+}
+
+function propertiesOf(marker: any): { [key: string]: any } | null {
+  if (marker && marker.feature && marker.feature.properties) {
+    return marker.feature.properties;
+  }
+  // KML の Point 以外はこちらの形で入ってくる
+  if (marker && marker.geojsondata && marker.geojsondata.properties) {
+    return marker.geojsondata.properties;
+  }
+  return null;
+}
+
+// 空文字は「値が無い」として扱う。CSV 由来のデータでは欠損が空文字で来る
+function hasValue(value: any): boolean {
+  return value !== undefined && value !== null && String(value).trim() !== '';
+}
+
+// 設定は JSON で書くので、true と "true"、1 と "1" を取り違えても
+// 書いたとおりに一致させる
+function matches(value: any, candidates: FilterValue[]): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  return candidates.some((candidate) => String(candidate) === String(value));
+}

--- a/test-unit/lib/sourceFilter.spec.js
+++ b/test-unit/lib/sourceFilter.spec.js
@@ -1,0 +1,104 @@
+import { filterMarkers } from '~/lib/sourceFilter';
+
+const marker = (properties) => ({
+  feature: { type: 'Feature', properties, geometry: { type: 'Point', coordinates: [130.6, 32.5] } },
+  category: properties.category || '未分類',
+});
+
+const markers = [
+  marker({ name: '氷川町給水所', category: '給水', source: '八代市公式X', status: 'open' }),
+  marker({ name: '春竹小学校', category: '避難所', source: '熊本県 防災情報くまもと', status: 'open' }),
+  marker({ name: '閉鎖された銭湯', category: '入浴・シャワー', source: 'RKK熊本放送', status: 'closed' }),
+  marker({ name: '市役所窓口', category: '行政手続き', source: '熊本市防災情報ポータル', status: 'open' }),
+];
+
+const names = (list) => list.map((m) => m.feature.properties.name);
+
+describe('filterMarkers', () => {
+  test('returns every marker when no filter is configured', () => {
+    expect(filterMarkers(markers)).toHaveLength(4);
+    expect(filterMarkers(markers, null)).toHaveLength(4);
+  });
+
+  test('drops the sources listed in exclude', () => {
+    const filtered = filterMarkers(markers, {
+      exclude: { source: ['熊本県 防災情報くまもと', '熊本市防災情報ポータル'] },
+    });
+    expect(names(filtered)).toEqual(['氷川町給水所', '閉鎖された銭湯']);
+  });
+
+  test('keeps only the values listed in include', () => {
+    const filtered = filterMarkers(markers, { include: { status: ['open'] } });
+    expect(names(filtered)).toEqual(['氷川町給水所', '春竹小学校', '市役所窓口']);
+  });
+
+  test('applies include and exclude together', () => {
+    const filtered = filterMarkers(markers, {
+      include: { status: ['open'] },
+      exclude: { source: ['熊本県 防災情報くまもと', '熊本市防災情報ポータル'] },
+    });
+    expect(names(filtered)).toEqual(['氷川町給水所']);
+  });
+
+  test('drops markers that lack a required property', () => {
+    const withoutSource = markers.concat(marker({ name: '出典不明', category: '給水' }));
+    const filtered = filterMarkers(withoutSource, { require: ['source'] });
+    expect(names(filtered)).not.toContain('出典不明');
+    expect(filtered).toHaveLength(4);
+  });
+
+  test('treats an empty string as a missing value', () => {
+    const blank = [marker({ name: '出典が空', category: '給水', source: '  ' })];
+    expect(filterMarkers(blank, { require: ['source'] })).toHaveLength(0);
+  });
+
+  test('does not silently pass everything when the excluded property disappears', () => {
+    // 提供元がフィールド名を変えた場合。exclude だけだと全件通ってしまう
+    const renamed = [marker({ name: '出典キーが変わった', category: '給水', src: '熊本市防災情報ポータル' })];
+    expect(filterMarkers(renamed, { exclude: { source: ['熊本市防災情報ポータル'] } })).toHaveLength(1);
+    expect(
+      filterMarkers(renamed, {
+        require: ['source'],
+        exclude: { source: ['熊本市防災情報ポータル'] },
+      })
+    ).toHaveLength(0);
+  });
+
+  test('matches values written with a different JSON type', () => {
+    const mixed = [
+      marker({ name: '公式', category: '給水', official: true }),
+      marker({ name: '非公式', category: '給水', official: false }),
+    ];
+    expect(names(filterMarkers(mixed, { include: { official: ['true'] } }))).toEqual(['公式']);
+    expect(names(filterMarkers(mixed, { include: { official: [true] } }))).toEqual(['公式']);
+  });
+
+  test('keeps markers without properties unless a positive condition is set', () => {
+    const shapes = [{ geojsondata: {}, category: '通行可能道路' }];
+    expect(filterMarkers(shapes, { exclude: { source: ['熊本市防災情報ポータル'] } })).toHaveLength(1);
+    expect(filterMarkers(shapes, { require: ['source'] })).toHaveLength(0);
+    expect(filterMarkers(shapes, { include: { status: ['open'] } })).toHaveLength(0);
+  });
+
+  test('drops values outside the include list even when they are new', () => {
+    // 本番 config と同形。提供元が新しい status 値を足しても素通りしない
+    const production = {
+      require: ['reuse'],
+      include: { reuse: ['open'], status: ['open', 'limited'] },
+    };
+    const data = [
+      marker({ name: '営業中GS', category: 'ガソリンスタンド', reuse: 'open', status: 'open' }),
+      marker({ name: '時間限定給水', category: '給水', reuse: 'open', status: 'limited' }),
+      marker({ name: '状況不明GS', category: 'ガソリンスタンド', reuse: 'open', status: 'unknown' }),
+      marker({ name: 'ポータル由来', category: '避難所', reuse: 'inquiry_required', status: 'open' }),
+      marker({ name: 'reuse無し', category: '給水', status: 'open' }),
+    ];
+    expect(names(filterMarkers(data, production))).toEqual(['営業中GS', '時間限定給水']);
+  });
+
+  test('does not modify the given array', () => {
+    const original = markers.slice();
+    filterMarkers(markers, { include: { status: ['open'] } });
+    expect(markers).toEqual(original);
+  });
+});


### PR DESCRIPTION
Closes #557

令和8年熊本地震の紙マップを追加します。#557 で協議した方針（開設状況のない台帳は使わない・出典で機械的に選別する）を実装したものです。

## 内容（2 commits）

**1. `sources[]` に宣言的フィルタを追加**（`lib/sourceFilter.ts` + 単体試験 10 ケース + `PrintableMap.vue` 3 行）

- `require` / `include` / `exclude` を config 側に書くと、読み込んだ地物を絞り込めます
- `filter` を書いていない既存の地図は、これまでどおり全件表示です（挙動不変）

**2. 熊本地震の config**（`assets/config/2026-kumamoto-earthquake.json` + `list.json` 先頭登録）

- データは平田さん（@tomo3141592653）の毎時更新 GeoJSON を参照します
- 10 カテゴリ（避難所・給水・入浴・シャワー・医療・薬局・トイレ・炊き出し・ガソリンスタンド・充電・通信・行政手続き・コンビニ・スーパー・金融）にアイコンと色を割り当てています

## フィルタは `reuse` フィールドに追従します

公開された `spots-geo.json` を確認したところ、全 750 件のうち県・熊本市ポータル由来の 383 件も**含まれており**、各地物に `reuse: "open"` / `"inquiry_required"` のフィールドが付与されていました（inquiry_required の内訳は 熊本県 防災情報くまもと 206 / 熊本市防災情報ポータル 175 / 熊本市災害対策本部会議資料 2）。

そこで #557 でご提案いただいた出典名の列挙ではなく、`reuse` で選別する形にしました:

```json
"filter": {
  "require": ["reuse"],
  "include": {
    "reuse": ["open"],
    "status": ["open", "limited"]
  }
}
```

- 提供元の `reuse` 判断に自動追従します（今後出典が増えても config の変更が不要です）
- 全条件を `include`（許可リスト）方式にしています。紙は配ったあとで訂正できないので、フィールドが無くなった・提供元が新しい値を足した、のどちらの場合も載せない側に倒れます（例: `status: "unknown"` のガソリンスタンド 1 件は刷りません）
- `status` は `open` と `limited`（時間・対象の制限つきで利用可）だけ刷ります。`closed`（閉鎖済み）は刷りません

## 検証（2026-07-31・実データ）

- lint 0 errors / `yarn test:unit` 25 passed（本番 config と同形のフィルタ試験を含む）/ `yarn generate --fail-on-error` 成功
- Playwright 実描画: ライブデータ 750 件 → フィルタ後 352 件のうち、初期表示範囲内の **350 個が全 10 カテゴリとも期待どおりのアイコンで描画**（残り 2 件＝水俣市湯の鶴温泉・黒川温泉は初期範囲の外で、表示を動かせば出ます）
- 県・市ポータル由来、閉鎖済み、営業状況 unknown が DOM に一切出ないことを確認
- 吹き出しに出典（source）と時刻（as_of）が出ることを確認

## 補足

- `description` は既存の地図（Google My Maps KML・GAS 出力）と同じ `v-html` の経路で表示されます。今回のデータも第三者提供である点は既存 sources と同じ性質です
- fork 内の事前チェックで CodeQL / eslint / test すべて green です

## スクリーンショット

| デスクトップ (1280px) | モバイル (390px) |
|---|---|
| ![desktop](https://raw.githubusercontent.com/yasumorishima/mapprint/screenshots/kumamoto-557/sc-desktop.png) | ![mobile](https://raw.githubusercontent.com/yasumorishima/mapprint/screenshots/kumamoto-557/sc-mobile.png) |
