### PR TITLE
chore: fix logo image path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 紙マップ
 ===
-![kamimap](static/images/logo.png)
+![kamimap](public/images/logo.png)
 
 Google マイマップ や、umap の情報を取り込んで、印刷向けに最適化して表示できるサイトのソースコードです。
 


### PR DESCRIPTION
## 概要 | About

このリポジトリ https://github.com/codeforjapan/mapprint のREADMEにあるロゴ画像が壊れていたので修正します。
画像のパスをstaticからpublicに変更した際に追従できていなかったようでした。

## 動作確認方法 | How to check

マージすると https://github.com/takahashim/mapprint/tree/fix-readme-logo のようになるはずです。

## スクリーンショット | Screenshot

### Before

<img width="824" height="337" alt="before-kamimap" src="https://github.com/user-attachments/assets/215d86e0-5c21-4e99-a65b-d865391580db" />


### After

<img width="829" height="684" alt="after-kamimap" src="https://github.com/user-attachments/assets/c78ff73f-288c-40c5-8cc8-af172717822c" />
